### PR TITLE
fix issue processing certain types at start of ShapeRecord

### DIFF
--- a/geozero-shp/src/property_processor.rs
+++ b/geozero-shp/src/property_processor.rs
@@ -6,53 +6,36 @@ use geozero::{ColumnValue, FeatureProperties, PropertyProcessor};
 impl FeatureProperties for ShapeRecord {
     /// Process feature properties.
     fn process_properties<P: PropertyProcessor>(&self, processor: &mut P) -> Result<bool> {
-        let mut finish = false;
-        let mut null_offset = 0usize;
-        for (i, (name, value)) in self.record.as_ref().iter().enumerate() {
-            let i = i - null_offset;
-            match value {
-                FieldValue::Character(Some(val)) => {
-                    finish = processor.property(i, name, &ColumnValue::String(val))?;
-                }
-                FieldValue::Numeric(Some(val)) => {
-                    finish = processor.property(i, name, &ColumnValue::Double(*val))?;
-                }
-                FieldValue::Logical(Some(val)) => {
-                    finish = processor.property(i, name, &ColumnValue::Bool(*val))?;
-                }
+        let mut i = 0;
+        for (name, value) in self.record.as_ref().iter() {
+            let finish = match value {
+                FieldValue::Character(Some(val)) => processor.property(i, name, &ColumnValue::String(val))?,
+                FieldValue::Numeric(Some(val)) => processor.property(i, name, &ColumnValue::Double(*val))?,
+                FieldValue::Logical(Some(val)) => processor.property(i, name, &ColumnValue::Bool(*val))?,
                 FieldValue::Date(Some(_)) => {
                     let s = format!("{}", value);
-                    finish = processor.property(i, name, &ColumnValue::DateTime(&s))?;
+                    processor.property(i, name, &ColumnValue::DateTime(&s))?
                 }
-                FieldValue::Float(Some(val)) => {
-                    finish = processor.property(i, name, &ColumnValue::Float(*val))?;
-                }
-                FieldValue::Integer(val) => {
-                    finish = processor.property(i, name, &ColumnValue::Int(*val))?;
-                }
-                FieldValue::Double(val) => {
-                    finish = processor.property(i, name, &ColumnValue::Double(*val))?;
-                }
-                FieldValue::Currency(val) => {
-                    finish = processor.property(i, name, &ColumnValue::Double(*val))?;
-                }
+                FieldValue::Float(Some(val)) => processor.property(i, name, &ColumnValue::Float(*val))?,
+                FieldValue::Integer(val) => processor.property(i, name, &ColumnValue::Int(*val))?,
+                FieldValue::Double(val) => processor.property(i, name, &ColumnValue::Double(*val))?,
+                FieldValue::Currency(val) => processor.property(i, name, &ColumnValue::Double(*val))?,
                 FieldValue::DateTime(_) => {
                     let s = format!("{}", value);
-                    finish = processor.property(i, name, &ColumnValue::DateTime(&s))?;
+                    processor.property(i, name, &ColumnValue::DateTime(&s))?
                 }
-                FieldValue::Memo(val) => {
-                    finish = processor.property(i, name, &ColumnValue::String(val))?;
-                }
+                FieldValue::Memo(val) => processor.property(i, name, &ColumnValue::String(val))?,
                 FieldValue::Character(None)
                 | FieldValue::Numeric(None)
                 | FieldValue::Logical(None)
                 | FieldValue::Date(None)
-                | FieldValue::Float(None) => { null_offset += 1 } // Ignore NULL values
-            }
+                | FieldValue::Float(None) => { continue; } // Ignore NULL values
+            };
             if finish {
-                break;
+                return Ok(true)
             }
+            i += 1;
         }
-        Ok(finish)
+        Ok(false)
     }
 }

--- a/geozero-shp/src/property_processor.rs
+++ b/geozero-shp/src/property_processor.rs
@@ -7,7 +7,9 @@ impl FeatureProperties for ShapeRecord {
     /// Process feature properties.
     fn process_properties<P: PropertyProcessor>(&self, processor: &mut P) -> Result<bool> {
         let mut finish = false;
+        let mut null_offset = 0usize;
         for (i, (name, value)) in self.record.as_ref().iter().enumerate() {
+            let i = i - null_offset;
             match value {
                 FieldValue::Character(Some(val)) => {
                     finish = processor.property(i, name, &ColumnValue::String(val))?;
@@ -45,7 +47,7 @@ impl FeatureProperties for ShapeRecord {
                 | FieldValue::Numeric(None)
                 | FieldValue::Logical(None)
                 | FieldValue::Date(None)
-                | FieldValue::Float(None) => {} // Ignore NULL values
+                | FieldValue::Float(None) => { null_offset += 1 } // Ignore NULL values
             }
             if finish {
                 break;


### PR DESCRIPTION
I ran into a situation when reading a shapefile into geojson where, if the first property of a given record is null (and thereby omitted by the processor), a comma is written by the GeoJsonWriter for the next property resulting in invalid JSON like `{, "second_property": 123}`

This change offsets the `i` value given to the GeoJsonWriter (or whatever writer) when we're skipping null properties.