### PR TITLE
ensure complete writes

### DIFF
--- a/geozero/src/geojson/geojson_writer.rs
+++ b/geozero/src/geojson/geojson_writer.rs
@@ -18,7 +18,7 @@ impl<'a, W: Write> GeoJsonWriter<'a, W> {
     }
     fn comma(&mut self, idx: usize) -> Result<()> {
         if idx > 0 {
-            let _ = self.out.write(b",")?;
+            self.out.write_all(b",")?;
         }
         Ok(())
     }
@@ -26,44 +26,44 @@ impl<'a, W: Write> GeoJsonWriter<'a, W> {
 
 impl<W: Write> FeatureProcessor for GeoJsonWriter<'_, W> {
     fn dataset_begin(&mut self, name: Option<&str>) -> Result<()> {
-        let _ = self.out.write(
+        self.out.write_all(
             br#"{
 "type": "FeatureCollection""#,
         )?;
         if let Some(name) = name {
             write!(self.out, ",\n\"name\": \"{}\"", name)?;
         }
-        let _ = self.out.write(
+        self.out.write_all(
             br#",
 "features": ["#,
         )?;
         Ok(())
     }
     fn dataset_end(&mut self) -> Result<()> {
-        let _ = self.out.write(b"]}")?;
+        self.out.write_all(b"]}")?;
         Ok(())
     }
     fn feature_begin(&mut self, idx: u64) -> Result<()> {
         if idx > 0 {
-            let _ = self.out.write(b",\n")?;
+            self.out.write_all(b",\n")?;
         }
-        let _ = self.out.write(br#"{"type": "Feature""#)?;
+        self.out.write_all(br#"{"type": "Feature""#)?;
         Ok(())
     }
     fn feature_end(&mut self, _idx: u64) -> Result<()> {
-        let _ = self.out.write(b"}")?;
+        self.out.write_all(b"}")?;
         Ok(())
     }
     fn properties_begin(&mut self) -> Result<()> {
-        let _ = self.out.write(br#", "properties": {"#)?;
+        self.out.write_all(br#", "properties": {"#)?;
         Ok(())
     }
     fn properties_end(&mut self) -> Result<()> {
-        let _ = self.out.write(b"}")?;
+        self.out.write_all(b"}")?;
         Ok(())
     }
     fn geometry_begin(&mut self) -> Result<()> {
-        let _ = self.out.write(br#", "geometry": "#)?;
+        self.out.write_all(br#", "geometry": "#)?;
         Ok(())
     }
     fn geometry_end(&mut self) -> Result<()> {
@@ -77,7 +77,7 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
     }
     fn xy(&mut self, x: f64, y: f64, idx: usize) -> Result<()> {
         self.comma(idx)?;
-        let _ = self.out.write(&format!("[{},{}]", x, y).as_bytes())?;
+        self.out.write_all(&format!("[{},{}]", x, y).as_bytes())?;
         Ok(())
     }
     fn coordinate(
@@ -91,118 +91,115 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
         idx: usize,
     ) -> Result<()> {
         self.comma(idx)?;
-        let _ = self.out.write(&format!("[{},{}", x, y).as_bytes())?;
+        self.out.write_all(&format!("[{},{}", x, y).as_bytes())?;
         if let Some(z) = z {
-            let _ = self.out.write(&format!(",{}", z).as_bytes())?;
+            self.out.write_all(&format!(",{}", z).as_bytes())?;
         }
-        let _ = self.out.write(b"]")?;
+        self.out.write_all(b"]")?;
         Ok(())
     }
     fn point_begin(&mut self, idx: usize) -> Result<()> {
         self.comma(idx)?;
-        let _ = self.out.write(br#"{"type": "Point", "coordinates": "#)?;
+        self.out
+            .write_all(br#"{"type": "Point", "coordinates": "#)?;
         Ok(())
     }
     fn point_end(&mut self, _idx: usize) -> Result<()> {
-        let _ = self.out.write(b"}")?;
+        self.out.write_all(b"}")?;
         Ok(())
     }
     fn multipoint_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
         self.comma(idx)?;
-        let _ = self
-            .out
-            .write(br#"{"type": "MultiPoint", "coordinates": ["#)?;
+        self.out
+            .write_all(br#"{"type": "MultiPoint", "coordinates": ["#)?;
         Ok(())
     }
     fn multipoint_end(&mut self, _idx: usize) -> Result<()> {
-        let _ = self.out.write(b"]}")?;
+        self.out.write_all(b"]}")?;
         Ok(())
     }
     fn linestring_begin(&mut self, tagged: bool, _size: usize, idx: usize) -> Result<()> {
         self.comma(idx)?;
         if tagged {
-            let _ = self
-                .out
-                .write(br#"{"type": "LineString", "coordinates": ["#)?;
+            self.out
+                .write_all(br#"{"type": "LineString", "coordinates": ["#)?;
         } else {
-            let _ = self.out.write(b"[")?;
+            self.out.write_all(b"[")?;
         }
         Ok(())
     }
     fn linestring_end(&mut self, tagged: bool, _idx: usize) -> Result<()> {
         if tagged {
-            let _ = self.out.write(b"]}")?;
+            self.out.write_all(b"]}")?;
         } else {
-            let _ = self.out.write(b"]")?;
+            self.out.write_all(b"]")?;
         }
         Ok(())
     }
     fn multilinestring_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
         self.comma(idx)?;
-        let _ = self
-            .out
-            .write(br#"{"type": "MultiLineString", "coordinates": ["#)?;
+        self.out
+            .write_all(br#"{"type": "MultiLineString", "coordinates": ["#)?;
         Ok(())
     }
     fn multilinestring_end(&mut self, _idx: usize) -> Result<()> {
-        let _ = self.out.write(b"]}")?;
+        self.out.write_all(b"]}")?;
         Ok(())
     }
     fn polygon_begin(&mut self, tagged: bool, _size: usize, idx: usize) -> Result<()> {
         self.comma(idx)?;
         if tagged {
-            let _ = self.out.write(br#"{"type": "Polygon", "coordinates": ["#)?;
+            self.out
+                .write_all(br#"{"type": "Polygon", "coordinates": ["#)?;
         } else {
-            let _ = self.out.write(b"[")?;
+            self.out.write_all(b"[")?;
         }
         Ok(())
     }
     fn polygon_end(&mut self, tagged: bool, _idx: usize) -> Result<()> {
         if tagged {
-            let _ = self.out.write(b"]}")?;
+            self.out.write_all(b"]}")?;
         } else {
-            let _ = self.out.write(b"]")?;
+            self.out.write_all(b"]")?;
         }
         Ok(())
     }
     fn multipolygon_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
         self.comma(idx)?;
-        let _ = self
-            .out
-            .write(br#"{"type": "MultiPolygon", "coordinates": ["#)?;
+        self.out
+            .write_all(br#"{"type": "MultiPolygon", "coordinates": ["#)?;
         Ok(())
     }
     fn multipolygon_end(&mut self, _idx: usize) -> Result<()> {
-        let _ = self.out.write(b"]}")?;
+        self.out.write_all(b"]}")?;
         Ok(())
     }
     fn geometrycollection_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
         self.comma(idx)?;
-        let _ = self
-            .out
-            .write(br#"{"type": "GeometryCollection", "geometries": ["#)?;
+        self.out
+            .write_all(br#"{"type": "GeometryCollection", "geometries": ["#)?;
         Ok(())
     }
     fn geometrycollection_end(&mut self, _idx: usize) -> Result<()> {
-        let _ = self.out.write(b"]}")?;
+        self.out.write_all(b"]}")?;
         Ok(())
     }
 }
 
 fn write_num_prop<'a, W: Write>(out: &'a mut W, colname: &str, v: &dyn Display) -> Result<()> {
-    let _ = out.write(&format!(r#""{}": {}"#, colname, v).as_bytes())?;
+    out.write_all(&format!(r#""{}": {}"#, colname, v).as_bytes())?;
     Ok(())
 }
 
 fn write_str_prop<'a, W: Write>(out: &'a mut W, colname: &str, v: &dyn Display) -> Result<()> {
-    let _ = out.write(&format!(r#""{}": "{}""#, colname, v).as_bytes())?;
+    out.write_all(&format!(r#""{}": "{}""#, colname, v).as_bytes())?;
     Ok(())
 }
 
 impl<W: Write> PropertyProcessor for GeoJsonWriter<'_, W> {
     fn property(&mut self, i: usize, colname: &str, colval: &ColumnValue) -> Result<bool> {
         if i > 0 {
-            let _ = self.out.write(b", ")?;
+            self.out.write_all(b", ")?;
         }
         match colval {
             ColumnValue::Byte(v) => write_num_prop(self.out, colname, &v)?,

--- a/geozero/src/svg/svg.rs
+++ b/geozero/src/svg/svg.rs
@@ -42,17 +42,16 @@ impl<'a, W: Write> SvgWriter<'a, W> {
 
 impl<W: Write> FeatureProcessor for SvgWriter<'_, W> {
     fn dataset_begin(&mut self, name: Option<&str>) -> Result<()> {
-        let _ = self.out.write(
+        self.out.write_all(
             br#"<?xml version="1.0"?>
 <svg xmlns="http://www.w3.org/2000/svg" version="1.2" baseProfile="tiny" "#,
         )?;
         if let Some((width, height)) = self.size {
-            let _ = self
-                .out
-                .write(&format!("width=\"{}\" height=\"{}\" ", width, height).as_bytes())?;
+            self.out
+                .write_all(&format!("width=\"{}\" height=\"{}\" ", width, height).as_bytes())?;
         }
         if let Some((xmin, ymin, xmax, ymax)) = self.view_box {
-            let _ = self.out.write(
+            self.out.write_all(
                 &format!(
                     "viewBox=\"{} {} {} {}\" ",
                     xmin,
@@ -63,22 +62,22 @@ impl<W: Write> FeatureProcessor for SvgWriter<'_, W> {
                 .as_bytes(),
             )?;
         }
-        let _ = self.out.write(
+        self.out.write_all(
             br#"stroke-linecap="round" stroke-linejoin="round">
 <g id=""#,
         )?;
         if let Some(name) = name {
-            let _ = self.out.write(name.as_bytes())?;
+            self.out.write_all(name.as_bytes())?;
         }
-        let _ = self.out.write(br#"">"#)?;
+        self.out.write_all(br#"">"#)?;
         Ok(())
     }
     fn dataset_end(&mut self) -> Result<()> {
-        let _ = self.out.write(b"\n</g>\n</svg>")?;
+        self.out.write_all(b"\n</g>\n</svg>")?;
         Ok(())
     }
     fn feature_begin(&mut self, _idx: u64) -> Result<()> {
-        let _ = self.out.write(b"\n")?;
+        self.out.write_all(b"\n")?;
         Ok(())
     }
     fn feature_end(&mut self, _idx: u64) -> Result<()> {
@@ -89,47 +88,47 @@ impl<W: Write> FeatureProcessor for SvgWriter<'_, W> {
 impl<W: Write> GeomProcessor for SvgWriter<'_, W> {
     fn xy(&mut self, x: f64, y: f64, _idx: usize) -> Result<()> {
         let y = if self.invert_y { -y } else { y };
-        let _ = self.out.write(&format!("{} {} ", x, y).as_bytes())?;
+        self.out.write_all(&format!("{} {} ", x, y).as_bytes())?;
         Ok(())
     }
     fn point_begin(&mut self, _idx: usize) -> Result<()> {
-        let _ = self.out.write(br#"<path d="M "#)?;
+        self.out.write_all(br#"<path d="M "#)?;
         Ok(())
     }
     fn point_end(&mut self, _idx: usize) -> Result<()> {
-        let _ = self.out.write(br#"Z"/>"#)?;
+        self.out.write_all(br#"Z"/>"#)?;
         Ok(())
     }
     fn linestring_begin(&mut self, tagged: bool, _size: usize, _idx: usize) -> Result<()> {
         if tagged {
-            let _ = self.out.write(br#"<path d=""#)?;
+            self.out.write_all(br#"<path d=""#)?;
         } else {
-            let _ = self.out.write(b"M ")?;
+            self.out.write_all(b"M ")?;
         }
         Ok(())
     }
     fn linestring_end(&mut self, tagged: bool, _idx: usize) -> Result<()> {
         if tagged {
-            let _ = self.out.write(br#""/>"#)?;
+            self.out.write_all(br#""/>"#)?;
         } else {
-            let _ = self.out.write(b"Z ")?;
+            self.out.write_all(b"Z ")?;
         }
         Ok(())
     }
     fn multilinestring_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
-        let _ = self.out.write(br#"<path d=""#)?;
+        self.out.write_all(br#"<path d=""#)?;
         Ok(())
     }
     fn multilinestring_end(&mut self, _idx: usize) -> Result<()> {
-        let _ = self.out.write(br#""/>"#)?;
+        self.out.write_all(br#""/>"#)?;
         Ok(())
     }
     fn polygon_begin(&mut self, _tagged: bool, _size: usize, _idx: usize) -> Result<()> {
-        let _ = self.out.write(br#"<path d=""#)?;
+        self.out.write_all(br#"<path d=""#)?;
         Ok(())
     }
     fn polygon_end(&mut self, _tagged: bool, _idx: usize) -> Result<()> {
-        let _ = self.out.write(br#""/>"#)?;
+        self.out.write_all(br#""/>"#)?;
         Ok(())
     }
 }

--- a/geozero/src/wkb/wkb_writer.rs
+++ b/geozero/src/wkb/wkb_writer.rs
@@ -116,7 +116,7 @@ impl<'a, W: Write> WkbWriter<'a, W> {
     /// GPKG geometry header according to http://www.geopackage.org/spec/#gpb_format
     fn write_gpkg_header(&mut self) -> Result<()> {
         let magic = b"GP";
-        self.out.write(magic)?;
+        self.out.write_all(magic)?;
         let version: u8 = 0;
         self.out.iowrite(version)?;
 

--- a/geozero/src/wkt/wkt_writer.rs
+++ b/geozero/src/wkt/wkt_writer.rs
@@ -17,24 +17,24 @@ impl<'a, W: Write> WktWriter<'a, W> {
     }
     fn geom_begin(&mut self, idx: usize, tag: &[u8]) -> Result<()> {
         if idx > 0 {
-            let _ = self.out.write(b",")?;
+            self.out.write_all(b",")?;
         }
-        let _ = self.out.write(tag)?;
+        self.out.write_all(tag)?;
         Ok(())
     }
     fn tagged_geom_begin(&mut self, tagged: bool, idx: usize, tag: &[u8]) -> Result<()> {
         if idx > 0 {
-            let _ = self.out.write(b",")?;
+            self.out.write_all(b",")?;
         }
         if tagged {
-            let _ = self.out.write(tag)?;
+            self.out.write_all(tag)?;
         } else {
-            let _ = self.out.write(b"(")?;
+            self.out.write_all(b"(")?;
         }
         Ok(())
     }
     fn geom_end(&mut self) -> Result<()> {
-        let _ = self.out.write(b")")?;
+        self.out.write_all(b")")?;
         Ok(())
     }
 }
@@ -45,9 +45,9 @@ impl<W: Write> GeomProcessor for WktWriter<'_, W> {
     }
     fn xy(&mut self, x: f64, y: f64, idx: usize) -> Result<()> {
         if idx == 0 {
-            let _ = self.out.write(&format!("{} {}", x, y).as_bytes())?;
+            self.out.write_all(&format!("{} {}", x, y).as_bytes())?;
         } else {
-            let _ = self.out.write(&format!(",{} {}", x, y).as_bytes())?;
+            self.out.write_all(&format!(",{} {}", x, y).as_bytes())?;
         }
         Ok(())
     }
@@ -62,15 +62,15 @@ impl<W: Write> GeomProcessor for WktWriter<'_, W> {
         idx: usize,
     ) -> Result<()> {
         if idx == 0 {
-            let _ = self.out.write(&format!("{} {}", x, y).as_bytes())?;
+            self.out.write_all(&format!("{} {}", x, y).as_bytes())?;
         } else {
-            let _ = self.out.write(&format!(",{} {}", x, y).as_bytes())?;
+            self.out.write_all(&format!(",{} {}", x, y).as_bytes())?;
         }
         if let Some(z) = z {
-            let _ = self.out.write(&format!(" {}", z).as_bytes())?;
+            self.out.write_all(&format!(" {}", z).as_bytes())?;
         }
         if let Some(m) = m {
-            let _ = self.out.write(&format!(" {}", m).as_bytes())?;
+            self.out.write_all(&format!(" {}", m).as_bytes())?;
         }
         Ok(())
     }
@@ -118,7 +118,7 @@ impl<W: Write> GeomProcessor for WktWriter<'_, W> {
         self.geom_end()
     }
     fn geometrycollection_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
-        let _ = self.out.write(b"GEOMETRYCOLLECTION(")?;
+        self.out.write_all(b"GEOMETRYCOLLECTION(")?;
         Ok(())
     }
     fn geometrycollection_end(&mut self, _idx: usize) -> Result<()> {


### PR DESCRIPTION
In practice, most implementations of `write` will completely write small bytes, but it's ultimately up to the underlying implementation if it wants to do a partial write. If we want to be sure the entire input is written out, we should use `write_all`.

If we did want to use `write` we'd need some kind of recursion/looping to be sure all the output is written.

Note in some places we use an `iowrite` method, as in: `self.out.iowrite(byte_order as u8)?;`, but that implementation safely delegates to `write_all` so no change is needed for those calls.