### PR TITLE
Use `prost-build` only with `with-mvt` flag in build script

### DIFF
--- a/geozero/Cargo.toml
+++ b/geozero/Cargo.toml
@@ -24,7 +24,7 @@ with-wkb = ["scroll", "with-wkt"]
 with-gpkg = ["with-wkb", "sqlx/sqlite"]
 with-postgis-sqlx = ["with-wkb", "sqlx/postgres"]
 with-postgis-postgres = ["with-wkb", "postgres-types", "bytes"]
-with-mvt = ["prost"]
+with-mvt = ["prost", "prost-build"]
 with-tessellator = ["lyon"]
 
 [dependencies]
@@ -60,7 +60,7 @@ sqlx = { version = "0.6", default-features = false, features = [ "runtime-tokio-
 tokio = { version = "1.17.0", default-features = false, features = ["macros"] }
 
 [build-dependencies]
-prost-build = "0.10"
+prost-build = { version = "0.10", optional = true }
 
 [package.metadata.docs.rs]
 #all-features = true

--- a/geozero/build.rs
+++ b/geozero/build.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "with-mvt")]
 use std::{
     env,
     fs::OpenOptions,
@@ -5,7 +6,8 @@ use std::{
     path::Path,
 };
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[cfg(feature = "with-mvt")]
+fn compile_protos() -> Result<(), Box<dyn std::error::Error>> {
     // override the build location, in order to check in the changes to proto files
     env::set_var("OUT_DIR", "src/mvt");
 
@@ -33,5 +35,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // As the proto file is checked in, the build should not fail if the file is not found
+    Ok(())
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "with-mvt")]
+    compile_protos()?;
+
     Ok(())
 }


### PR DESCRIPTION
This PR makes the lib use `prost-build` only when the feature
`with-mvt` is enabled, once protobuf stuff is used only in this
feature.

I am opening this PR because I am working on a project that doesn't use
the `with-mvt` flag and protobufs and it spends 31s compiling this dep
 anyway.

I forked this repository, applied this patch, and used it in my project
and it worked flawlessly.
 
 I've run the tests and this patch doesn't break anything, but if there is something
 weird in this PR, please let me know :)