### PR TITLE
Add `Gpx` which impls GeozeroGeometry and example failing tests

### DIFF
--- a/geozero/src/gpx/gpx_reader.rs
+++ b/geozero/src/gpx/gpx_reader.rs
@@ -1,8 +1,9 @@
-use crate::error::GeozeroError;
+use crate::error::{GeozeroError, Result};
 use std::io;
 
 /// GPX reader
 pub struct GpxReader<'a, R: io::Read>(pub &'a mut R);
+pub struct Gpx<'a>(pub &'a str);
 
 impl<'a, R: io::Read> crate::GeozeroDatasource for GpxReader<'a, R> {
     fn process<P: crate::FeatureProcessor>(
@@ -10,6 +11,12 @@ impl<'a, R: io::Read> crate::GeozeroDatasource for GpxReader<'a, R> {
         processor: &mut P,
     ) -> crate::error::Result<()> {
         read_gpx(&mut self.0, processor)
+    }
+}
+
+impl<'a> crate::GeozeroGeometry for Gpx<'a> {
+    fn process_geom<P: crate::GeomProcessor>(&self, processor: &mut P) -> Result<()> {
+        read_gpx(&mut self.0.as_bytes(), processor)
     }
 }
 

--- a/geozero/src/gpx/mod.rs
+++ b/geozero/src/gpx/mod.rs
@@ -1,4 +1,4 @@
 mod gpx_reader;
 
 pub use gpx_reader::read_gpx;
-pub use gpx_reader::GpxReader;
+pub use gpx_reader::{Gpx, GpxReader};

--- a/geozero/src/gpx/mod.rs
+++ b/geozero/src/gpx/mod.rs
@@ -1,3 +1,4 @@
 mod gpx_reader;
 
 pub use gpx_reader::read_gpx;
+pub use gpx_reader::GpxReader;

--- a/geozero/tests/gpx.rs
+++ b/geozero/tests/gpx.rs
@@ -1,3 +1,6 @@
+use geozero::gpx::{Gpx, GpxReader};
+use serde_json::json;
+
 use std::io;
 
 mod test_writer;
@@ -74,4 +77,88 @@ fn test_wikipedia_example() {
             Cmd::MultiLineStringEnd { idx: 0 },
         ]
     );
+}
+
+mod wikipedia_example_conversions {
+    use super::*;
+
+    #[test]
+    fn to_json() {
+        let gpx_str = include_str!("data/wikipedia_example.gpx");
+        let mut cursor = io::Cursor::new(gpx_str);
+        let mut reader = GpxReader(&mut cursor);
+
+        use geozero::ProcessToJson;
+        let geojson = reader.to_json().unwrap();
+        assert_eq!(
+            r#"{"type": "MultiLineString", "coordinates": [[[-122.326897,47.644548],[-122.326897,47.644548],[-122.326897,47.644548]]]}"#,
+            geojson
+        );
+    }
+
+    #[test]
+    fn to_svg() {
+        let gpx_str = include_str!("data/wikipedia_example.gpx");
+        let mut cursor = io::Cursor::new(gpx_str);
+        let mut reader = GpxReader(&mut cursor);
+
+        use geozero::ProcessToSvg;
+        let geojson = reader.to_svg().unwrap();
+        assert_eq!(
+            r#"<path d="M -122.326897 47.644548 -122.326897 47.644548 -122.326897 47.644548 Z "/>"#,
+            geojson
+        );
+    }
+
+    #[test]
+    fn to_wkt() {
+        let gpx_str = include_str!("data/wikipedia_example.gpx");
+        let mut reader = Gpx(gpx_str);
+
+        use geozero::ToWkt;
+        let wkt = reader.to_wkt().unwrap();
+        assert_eq!(
+            r#"MULTILINESTRING((-122.326897 47.644548,-122.326897 47.644548,-122.326897 47.644548))"#,
+            wkt
+        );
+    }
+}
+
+mod extensive_conversion {
+    use super::*;
+
+    #[test]
+    fn to_geojson() {
+        let gpx_str = include_str!("data/extensive.gpx");
+        let mut cursor = io::Cursor::new(gpx_str);
+        let mut reader = GpxReader(&mut cursor);
+
+        use geozero::ProcessToJson;
+        let geojson = reader.to_json().unwrap();
+        let actual_json: serde_json::Value = serde_json::from_str(&geojson).unwrap();
+        let expected_json: serde_json::Value = serde_json::from_str(r#""to fill in""#).unwrap();
+        assert_eq!(actual_json, expected_json)
+    }
+
+    #[test]
+    fn to_svg() {
+        let gpx_str = include_str!("data/extensive.gpx");
+        let mut reader = Gpx(gpx_str);
+
+        use geozero::ToSvg;
+        let actual_svg = reader.to_svg().unwrap();
+        let expected_svg: &str = "to fill in";
+        assert_eq!(expected_svg, actual_svg);
+    }
+
+    #[test]
+    fn to_wkt() {
+        let gpx_str = include_str!("data/extensive.gpx");
+        let mut reader = Gpx(gpx_str);
+
+        use geozero::ToWkt;
+        let wkt = reader.to_wkt().unwrap();
+        let expected_wkt: &str = "to fill in";
+        assert_eq!(expected_wkt, wkt);
+    }
 }

--- a/geozero/tests/test_writer.rs
+++ b/geozero/tests/test_writer.rs
@@ -110,7 +110,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn linestring_begin(&mut self, tagged: bool, _size: usize, idx: usize) -> Result<()> {
+    fn linestring_begin(&mut self, _tagged: bool, _size: usize, idx: usize) -> Result<()> {
         self.0.push(Cmd::LineStringBegin { idx });
         Ok(())
     }
@@ -130,7 +130,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn polygon_begin(&mut self, tagged: bool, _size: usize, idx: usize) -> Result<()> {
+    fn polygon_begin(&mut self, _tagged: bool, _size: usize, idx: usize) -> Result<()> {
         self.0.push(Cmd::PolygonBegin { idx });
         Ok(())
     }
@@ -160,7 +160,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn circularstring_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
+    fn circularstring_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
         Ok(())
     }
 
@@ -168,7 +168,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn compoundcurve_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
+    fn compoundcurve_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
         Ok(())
     }
 
@@ -176,7 +176,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn curvepolygon_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
+    fn curvepolygon_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
         Ok(())
     }
 
@@ -184,7 +184,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn multicurve_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
+    fn multicurve_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
         Ok(())
     }
 
@@ -192,7 +192,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn multisurface_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
+    fn multisurface_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
         Ok(())
     }
 
@@ -200,7 +200,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn triangle_begin(&mut self, tagged: bool, _size: usize, idx: usize) -> Result<()> {
+    fn triangle_begin(&mut self, _tagged: bool, _size: usize, _idx: usize) -> Result<()> {
         Ok(())
     }
 
@@ -208,7 +208,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn polyhedralsurface_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
+    fn polyhedralsurface_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
         Ok(())
     }
 
@@ -216,7 +216,7 @@ impl geozero::GeomProcessor for TestWriter {
         Ok(())
     }
 
-    fn tin_begin(&mut self, _size: usize, idx: usize) -> Result<()> {
+    fn tin_begin(&mut self, _size: usize, _idx: usize) -> Result<()> {
         Ok(())
     }
 


### PR DESCRIPTION
Note this is targeting @frewsxcv'd PR #48 

The hope is to make sure the new data source aligns with the expectations of the existing processors. Currently some invalid input is produced.

In particular, there's no separation between the various elements in the case of converting the "comprehensive" test file to other formats.

e.g. to_wkt produces: `MULTIPOINT(-1.5153741828293 47.253146555709,-1.5482325613225 47.235331031612)MULTILINESTRING((-1.55` (note the lack of separator before MULTILINESTRING. 

I also think that, like our geo-types output, that this should produce a top level GeometryCollection to contain the multiple geometries, since WKT doesn't support multiple top level geometries (see #35 for a related discussion about how geojson FeatureCollections to WKT produces invalid output)

Similarly the current output of `gpx.to_json()` is not parsable.
