### PR TITLE
Updating the dbase version to 0.3 and exporting the now public FieldType

### DIFF
--- a/geozero-shp/Cargo.toml
+++ b/geozero-shp/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["geo", "shapefile"]
 thiserror = "1.0"
 geozero = { version = "0.9.4", default-features = false }
 byteorder = "1.4.3"
-dbase = "0.2.3"
+dbase = "0.3"
 
 [dev-dependencies]
 geozero = { version = "0.9.4", default-features = true }

--- a/geozero-shp/src/reader.rs
+++ b/geozero-shp/src/reader.rs
@@ -1,7 +1,7 @@
 use crate::shp_reader::{read_shape, RecordHeader};
 use crate::shx_reader::{read_index_file, ShapeIndex};
 use crate::{header, Error};
-pub use dbase::FieldInfo;
+pub use dbase::{FieldInfo,FieldType};
 use geozero::{FeatureProcessor, FeatureProperties, GeomProcessor};
 use std::fs::File;
 use std::io::{BufReader, Read, Seek};


### PR DESCRIPTION
The use case for this is so that the following is possible

use geozero_shp::reader::FieldType;

    reader.dbf_fields().unwrap().iter().for_each(
        |f| {
            println!("{} {} len {}",f.name(),f.field_type(),f.length());
            let ft=match f.field_type() {
                FieldType::Character => {"char"}
                // FieldType::Date => {}
                // FieldType::Float => {}
                FieldType::Numeric => {"num"}
                // FieldType::Logical => {}
                // FieldType::Currency => {}
                // FieldType::DateTime => {}
                // FieldType::Integer => {}
                // FieldType::Double => {}
                // FieldType::Memo => {}
                _ => {"other"}
            };
            println!("{}",ft);
        }