### PR TITLE
ci: setup dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "8:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
This library has a few dependencies. Let's setup dependabot to keep them up-to-date.

