### PR TITLE
Adds diesel support for Ewkb type for postgis

### DIFF
--- a/geozero/Cargo.toml
+++ b/geozero/Cargo.toml
@@ -25,6 +25,7 @@ with-gpkg = ["with-wkb", "sqlx/sqlite"]
 with-gpx = ["gpx"]
 with-postgis-sqlx = ["with-wkb", "sqlx/postgres"]
 with-postgis-postgres = ["with-wkb", "postgres-types", "bytes"]
+with-postgis-diesel = ["with-wkb", "diesel", "byteorder"]
 with-mvt = ["prost", "prost-build"]
 with-tessellator = ["lyon"]
 
@@ -42,6 +43,8 @@ lyon = { version = "1.0", optional = true }
 log = "0.4.17"
 scroll = { version = "0.11", optional = true }
 sqlx = { version = "0.6", default-features = false, optional = true }
+diesel = { version = "2.0.2", default-features = false, optional = true }
+byteorder = { version = "1.4.3", default-features = false, optional = true }
 postgres-types = { version = "0.2", optional = true }
 bytes = { version = "1.0", optional = true }
 prost = { version = "0.11.0", optional = true }
@@ -59,6 +62,7 @@ flatgeobuf = "3.24.0"
 #flatgeobuf = { git = "https://github.com/pka/flatgeobuf", branch="geozero-0.9" }
 postgres = "0.19"
 sqlx = { version = "0.6", default-features = false, features = [ "runtime-tokio-native-tls", "macros", "time", "postgres", "sqlite" ] }
+diesel = { version = "2.0.2", default-features = false, features = [ "postgres" ] }
 tokio = { version = "1.17.0", default-features = false, features = ["macros"] }
 
 [build-dependencies]

--- a/geozero/src/lib.rs
+++ b/geozero/src/lib.rs
@@ -78,7 +78,11 @@ pub mod gpkg;
 #[cfg(feature = "with-gpx")]
 pub mod gpx;
 
-#[cfg(any(feature = "with-postgis-postgres", feature = "with-postgis-sqlx"))]
+#[cfg(any(
+    feature = "with-postgis-postgres",
+    feature = "with-postgis-sqlx",
+    feature = "with-postgis-diesel"
+))]
 pub mod postgis;
 
 #[cfg(feature = "with-svg")]

--- a/geozero/src/postgis/mod.rs
+++ b/geozero/src/postgis/mod.rs
@@ -3,6 +3,8 @@
 //! All geometry types implementing [GeozeroGeometry](crate::GeozeroGeometry) can be encoded as PostGIS EWKB geometry using [wkb::Encode](crate::wkb::Encode).
 //!
 //! Geometry types implementing [FromWkb](crate::wkb::FromWkb) can be decoded from PostGIS geometries using [wkb::Decode](crate::wkb::Decode).
+#[cfg(feature = "with-postgis-diesel")]
+mod postgis_diesel;
 #[cfg(feature = "with-postgis-postgres")]
 mod postgis_postgres;
 #[cfg(feature = "with-postgis-sqlx")]
@@ -88,4 +90,67 @@ pub mod postgres {
 #[cfg(feature = "with-postgis-sqlx")]
 pub mod sqlx {
     pub use super::postgis_sqlx::*;
+}
+
+/// Postgis geometry type encoding for Diesel.
+///
+/// # PostGIS usage example with Diesel
+///
+/// Declare model and select Ewkb types directly with GeoZero and Diesel
+///
+/// ```
+/// use diesel::pg::PgConnection;
+/// use diesel::{Connection, QueryDsl, RunQueryDsl};
+/// use diesel::prelude::*;
+///
+/// use geozero::wkb::Ewkb;
+///
+/// diesel::table! {
+///     use diesel::sql_types::*;
+///     use geozero::postgis::diesel::sql_types::*;
+///
+///     geometries (name) {
+///         name -> Varchar,
+///         geom -> Nullable<Geometry>,
+///     }
+/// }
+///
+/// #[derive(Queryable, Debug, Insertable)]
+/// #[diesel(table_name = geometries)]
+/// pub struct Geom {
+///     pub name: String,
+///     pub geom: Option<Ewkb>,
+/// }
+///
+/// pub fn establish_connection() -> PgConnection {
+///     let database_url = std::env::var("DATABASE_URL").expect("Unable to find database url.");
+///     PgConnection::establish(&database_url).unwrap()
+/// }
+///
+/// fn main() {
+///     let conn = &mut establish_connection();
+///
+///     let wkb = Ewkb(vec![
+///         1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 52, 192,
+///     ]);
+///
+///     let insert_geometry = Geom {
+///         name: "GeoZeroTest".to_string(),
+///         geom: Some(wkb),
+///     };
+///
+///     let inserted: Geom = diesel::insert_into(geometries::table)
+///         .values(&insert_geometry)
+///         .get_result(conn)
+///         .expect("Unable to insert into postgis");
+///
+///     let geometry_vec: Vec<Geom> = geometries::dsl::geometries
+///         .limit(10)
+///         .load::<Geom>(conn)
+///         .expect("Error loading geometries");
+/// }
+/// ```
+#[cfg(feature = "with-postgis-diesel")]
+pub mod diesel {
+    pub use super::postgis_diesel::*;
 }

--- a/geozero/src/postgis/mod.rs
+++ b/geozero/src/postgis/mod.rs
@@ -127,28 +127,29 @@ pub mod sqlx {
 ///     PgConnection::establish(&database_url).unwrap()
 /// }
 ///
-/// fn main() {
-///     let conn = &mut establish_connection();
+/// # async fn rust_geo_query() -> Result<(), diesel::result::Error> {
+/// let conn = &mut establish_connection();
 ///
-///     let wkb = Ewkb(vec![
-///         1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 52, 192,
-///     ]);
+/// let wkb = Ewkb(vec![
+///     1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 52, 192,
+/// ]);
 ///
-///     let insert_geometry = Geom {
-///         name: "GeoZeroTest".to_string(),
-///         geom: Some(wkb),
-///     };
+/// let insert_geometry = Geom {
+///     name: "GeoZeroTest".to_string(),
+///     geom: Some(wkb),
+/// };
 ///
-///     let inserted: Geom = diesel::insert_into(geometries::table)
-///         .values(&insert_geometry)
-///         .get_result(conn)
-///         .expect("Unable to insert into postgis");
+/// let inserted: Geom = diesel::insert_into(geometries::table)
+///     .values(&insert_geometry)
+///     .get_result(conn)
+///     .expect("Unable to insert into postgis");
 ///
-///     let geometry_vec: Vec<Geom> = geometries::dsl::geometries
-///         .limit(10)
-///         .load::<Geom>(conn)
-///         .expect("Error loading geometries");
-/// }
+/// let geometry_vec: Vec<Geom> = geometries::dsl::geometries
+///     .limit(10)
+///     .load::<Geom>(conn)
+///     .expect("Error loading geometries");
+/// # Ok(())
+/// # }
 /// ```
 #[cfg(feature = "with-postgis-diesel")]
 pub mod diesel {

--- a/geozero/src/postgis/postgis_diesel.rs
+++ b/geozero/src/postgis/postgis_diesel.rs
@@ -1,0 +1,51 @@
+use crate::postgis::postgis_diesel::sql_types::*;
+use crate::wkb::Ewkb;
+
+use byteorder::WriteBytesExt;
+
+use diesel::deserialize::{self, FromSql};
+use diesel::pg::{self, Pg};
+use diesel::serialize::{self, IsNull, Output, ToSql};
+
+pub mod sql_types {
+    use diesel::query_builder::QueryId;
+    use diesel::sql_types::SqlType;
+
+    #[derive(SqlType, QueryId)]
+    #[diesel(postgres_type(name = "geometry"))]
+    pub struct Geometry;
+
+    #[derive(SqlType, QueryId)]
+    #[diesel(postgres_type(name = "geography"))]
+    pub struct Geography;
+}
+
+impl ToSql<Geometry, Pg> for Ewkb {
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        for ewkb_byte in &self.0 {
+            out.write_u8(*ewkb_byte)?;
+        }
+        Ok(IsNull::No)
+    }
+}
+
+impl ToSql<Geography, Pg> for Ewkb {
+    fn to_sql(&self, out: &mut Output<Pg>) -> serialize::Result {
+        for ewkb_byte in &self.0 {
+            out.write_u8(*ewkb_byte)?;
+        }
+        Ok(IsNull::No)
+    }
+}
+
+impl FromSql<Geometry, Pg> for Ewkb {
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        Ok(Self(bytes.as_bytes().to_vec()))
+    }
+}
+
+impl FromSql<Geography, Pg> for Ewkb {
+    fn from_sql(bytes: pg::PgValue) -> deserialize::Result<Self> {
+        Ok(Self(bytes.as_bytes().to_vec()))
+    }
+}

--- a/geozero/src/wkb/wkb_reader.rs
+++ b/geozero/src/wkb/wkb_reader.rs
@@ -4,6 +4,11 @@ use crate::{GeomProcessor, GeozeroGeometry};
 use scroll::IOread;
 use std::io::Read;
 
+#[cfg(feature = "with-postgis-diesel")]
+use crate::postgis::diesel::sql_types::{Geography, Geometry};
+#[cfg(feature = "with-postgis-diesel")]
+use diesel::expression::AsExpression;
+
 /// WKB reader.
 pub struct Wkb(pub Vec<u8>);
 
@@ -14,6 +19,12 @@ impl GeozeroGeometry for Wkb {
 }
 
 /// EWKB reader.
+#[cfg_attr(
+    feature = "with-postgis-diesel",
+    derive(Debug, AsExpression, PartialEq)
+)]
+#[cfg_attr(feature = "with-postgis-diesel", diesel(sql_type = Geometry))]
+#[cfg_attr(feature = "with-postgis-diesel", diesel(sql_type = Geography))]
 pub struct Ewkb(pub Vec<u8>);
 
 impl GeozeroGeometry for Ewkb {


### PR DESCRIPTION
This additional allows for the seamless use of the Ewkb format in diesel to map to postgis geometry and geography types. Because postgis emits Ewkb for geometry types, we can make the wkb module an entrypoint into the GeoRust ecosystem and allow easy conversion to other types. While it is feasible to make any type that implements ToWkb and has a To* trait from wkb a base type in diesel, Ewkb is the most flexible because it is the base emission from postgis. 