### PR TITLE
Disable default features for `geojson`

### DIFF
--- a/geozero/Cargo.toml
+++ b/geozero/Cargo.toml
@@ -32,7 +32,7 @@ with-tessellator = ["lyon"]
 [dependencies]
 csv = { version = "1.1.6", optional = true }
 thiserror = "1.0"
-geojson = { version = "0.24.0", optional = true }
+geojson = { version = "0.24.0", default-features = false, optional = true }
 serde_json = "1.0.79"
 geo-types = { version = "0.7", default-features = false, optional = true }
 geos = { version = "8.0", optional = true }


### PR DESCRIPTION
We don't need the `geo-types` dependency