### PR TITLE
derive FromSqlRow for Ewkb

### DIFF
--- a/geozero/src/wkb/wkb_reader.rs
+++ b/geozero/src/wkb/wkb_reader.rs
@@ -7,7 +7,7 @@ use std::io::Read;
 #[cfg(feature = "with-postgis-diesel")]
 use crate::postgis::diesel::sql_types::{Geography, Geometry};
 #[cfg(feature = "with-postgis-diesel")]
-use diesel::expression::AsExpression;
+use diesel::{deserialize::FromSqlRow, expression::AsExpression};
 
 /// WKB reader.
 pub struct Wkb(pub Vec<u8>);
@@ -21,7 +21,7 @@ impl GeozeroGeometry for Wkb {
 /// EWKB reader.
 #[cfg_attr(
     feature = "with-postgis-diesel",
-    derive(Debug, AsExpression, PartialEq)
+    derive(Debug, AsExpression, FromSqlRow, PartialEq)
 )]
 #[cfg_attr(feature = "with-postgis-diesel", diesel(sql_type = Geometry))]
 #[cfg_attr(feature = "with-postgis-diesel", diesel(sql_type = Geography))]


### PR DESCRIPTION
Am new to both `geozero` and `diesel`, but for the queries I was trying to write, I needed to add this derive to execute the following (truncated) code:

The diesel errors were kind of inscrutable, but from what I could surmise, the general issue is that while `st_union_agg` (which is a SQL function I defined to wrap the aggregate version of PostGIS' `ST_Union`) returns a `geozero::postgis::diesel::sql_types::Geometry`, an `Ewkb` cannot be obtained from the select statement without explicit conversion, selecting the `Geometry` column itself, or without this trait implementation.

Sorry I can't provide a better explanation.

```rust
#[derive(Queryable)]
struct CollectionDiff {
    pub start: DateTime<Utc>,
    pub end: DateTime<Utc>,
    pub updated: DateTime<Utc>,
    pub footprint: Ewkb,
}

stac::table
    .select((
        min(stac::observed).assume_not_null(),
        max(stac::observed).assume_not_null(),
        max(stac::updated).assume_not_null(),
        st_union_agg(stac::geometry),
    ))
    .get_result::<CollectionDiff>(&mut conn)?;

```