### PR TITLE
Re-export prost::Message for mvt

### DIFF
--- a/geozero/src/mvt/mod.rs
+++ b/geozero/src/mvt/mod.rs
@@ -7,6 +7,7 @@ mod vector_tile;
 
 pub use mvt_reader::*;
 pub use mvt_writer::*;
+pub use prost::Message;
 pub use vector_tile::*;
 
 pub(crate) mod conversion {


### PR DESCRIPTION
The origin of this pull request was a problem on maplibre-rs: https://github.com/maplibre/maplibre-rs/pull/235

An mvt tile is a protobuf message, parsed with the prost library. That library gives us a trait to be able to

```rust
geozero::mvt::Tile::decode(raw_data)
```

However, the trait must be in the scope.

Until now, the solution was to have prost as an extra dependency and do

```rust
use prost::Message
```

This is a problem when the versions are not equivalent in a SemVer sense as it might break randomly.

This commits allows the program that uses `geozero::mvt` to do

```rust
use geozero::mvt::Message
```

and no longer have an explicit dependency to prost, and we no longer have the risk of version mismatch.