### PR TITLE
Don't require ownership for `Reader` iterators.

### DIFF
--- a/geozero-shp/src/shp_reader.rs
+++ b/geozero-shp/src/shp_reader.rs
@@ -32,8 +32,8 @@ impl RecordHeader {
 }
 
 /// Read and process one shape record
-pub(crate) fn read_shape<P: GeomProcessor, T: Read>(
-    processor: &mut P,
+pub(crate) fn read_shape<'a, P: GeomProcessor + 'a, T: Read>(
+    processor: &'a mut P,
     mut source: &mut T,
 ) -> Result<RecordHeader, Error> {
     let hdr = RecordHeader::read_from(&mut source)?;

--- a/geozero-shp/tests/reader.rs
+++ b/geozero-shp/tests/reader.rs
@@ -19,14 +19,14 @@ fn read_header() {
 fn iterate() -> Result<(), geozero_shp::Error> {
     let reader = geozero_shp::Reader::from_path("./tests/data/poly.shp")?;
     let mut cnt = 0;
-    for _ in reader.iter_geometries(ProcessorSink::new()) {
+    for _ in reader.iter_geometries(&mut ProcessorSink::new()) {
         cnt += 1;
     }
     assert_eq!(cnt, 10);
 
     let reader = geozero_shp::Reader::from_path("./tests/data/poly.shp")?;
     let mut cnt = 0;
-    for feat in reader.iter_features(ProcessorSink::new())? {
+    for feat in reader.iter_features(&mut ProcessorSink::new())? {
         if let Ok(feat) = feat {
             assert!(feat.property::<f64>("EAS_ID").unwrap() > 100.0);
         }
@@ -37,7 +37,7 @@ fn iterate() -> Result<(), geozero_shp::Error> {
     let source = BufReader::new(File::open("./tests/data/poly.shp")?);
     let reader = geozero_shp::Reader::new(source)?;
     let mut cnt = 0;
-    for _ in reader.iter_geometries(ProcessorSink::new()) {
+    for _ in reader.iter_geometries(&mut ProcessorSink::new()) {
         cnt += 1;
     }
     assert_eq!(cnt, 10);
@@ -49,7 +49,9 @@ fn iterate() -> Result<(), geozero_shp::Error> {
 fn shp_to_json() -> Result<(), geozero_shp::Error> {
     let reader = geozero_shp::Reader::from_path("./tests/data/poly.shp")?;
     let mut json: Vec<u8> = Vec::new();
-    let cnt = reader.iter_features(GeoJsonWriter::new(&mut json))?.count();
+    let cnt = reader
+        .iter_features(&mut GeoJsonWriter::new(&mut json))?
+        .count();
     assert_eq!(cnt, 10);
     assert_eq!(
         &from_utf8(&json).unwrap()[0..80],
@@ -70,7 +72,7 @@ fn shp_to_geo() -> Result<(), geozero_shp::Error> {
 
     let reader = geozero_shp::Reader::from_path("./tests/data/poly.shp")?;
     let mut cnt = 0;
-    for _ in reader.iter_geometries(GeoWriter::new()) {
+    for _ in reader.iter_geometries(&mut GeoWriter::new()) {
         cnt += 1;
     }
     assert_eq!(cnt, 10);
@@ -87,7 +89,7 @@ fn property_filter() -> Result<(), geozero_shp::Error> {
     let reader = geozero_shp::Reader::from_path("./tests/data/poly.shp")?;
     let mut json: Vec<u8> = Vec::new();
     let cnt = reader
-        .iter_features(GeoJsonWriter::new(&mut json))?
+        .iter_features(&mut GeoJsonWriter::new(&mut json))?
         .filter(|feat| feat.as_ref().unwrap().property::<f64>("AREA").unwrap() > 260000.0)
         .count();
     assert_eq!(cnt, 5);
@@ -100,7 +102,7 @@ fn property_filter() -> Result<(), geozero_shp::Error> {
 fn property_access() -> Result<(), geozero_shp::Error> {
     let reader = geozero_shp::Reader::from_path("./tests/data/poly.shp")?;
     let mut cnt = 0;
-    for feat in reader.iter_features(ProcessorSink::new())? {
+    for feat in reader.iter_features(&mut ProcessorSink::new())? {
         if let Ok(feat) = feat {
             // Access internal type
             if let Some(FieldValue::Numeric(Some(val))) = feat.record.get("EAS_ID") {
@@ -162,7 +164,9 @@ fn property_file() -> Result<(), geozero_shp::Error> {
 fn point() -> Result<(), geozero_shp::Error> {
     let reader = geozero_shp::Reader::from_path("./tests/data/point.shp")?;
     let mut wkt_data: Vec<u8> = Vec::new();
-    reader.iter_geometries(WktWriter::new(&mut wkt_data)).next();
+    reader
+        .iter_geometries(&mut WktWriter::new(&mut wkt_data))
+        .next();
     assert_eq!(from_utf8(&wkt_data).unwrap(), "POINT(122 37)");
     Ok(())
 }
@@ -173,7 +177,7 @@ fn pointzm() -> Result<(), geozero_shp::Error> {
     let mut wkt_data: Vec<u8> = Vec::new();
     let mut writer = WktWriter::new(&mut wkt_data);
     writer.dims.m = true;
-    reader.iter_geometries(writer).next();
+    reader.iter_geometries(&mut writer).next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "POINT(160477.9000324604 5403959.561417906 0)"
@@ -183,7 +187,7 @@ fn pointzm() -> Result<(), geozero_shp::Error> {
     let mut wkt_data: Vec<u8> = Vec::new();
     let mut writer = WktWriter::new(&mut wkt_data);
     writer.dims.z = true;
-    reader.iter_geometries(writer).next();
+    reader.iter_geometries(&mut writer).next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "POINT(1422464.3681007193 4188962.3364355816 72.40956470558095)"
@@ -195,7 +199,9 @@ fn pointzm() -> Result<(), geozero_shp::Error> {
 fn multipoint() -> Result<(), geozero_shp::Error> {
     let reader = geozero_shp::Reader::from_path("./tests/data/multipoint.shp")?;
     let mut wkt_data: Vec<u8> = Vec::new();
-    reader.iter_geometries(WktWriter::new(&mut wkt_data)).next();
+    reader
+        .iter_geometries(&mut WktWriter::new(&mut wkt_data))
+        .next();
     assert_eq!(from_utf8(&wkt_data).unwrap(), "MULTIPOINT(122 37,124 32)");
     Ok(())
 }
@@ -206,7 +212,7 @@ fn multipointzm() -> Result<(), geozero_shp::Error> {
     let mut wkt_data: Vec<u8> = Vec::new();
     let mut writer = WktWriter::new(&mut wkt_data);
     writer.dims.z = true;
-    reader.iter_geometries(writer).next();
+    reader.iter_geometries(&mut writer).next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTIPOINT(1422671.7232666016 4188903.4295959473 72.00995635986328,1422672.1022949219 4188903.4295959473 72.0060806274414,1422671.9127807617 4188903.7578430176 72.00220489501953,1422671.9127807617 4188903.539001465 71.99445343017578)"
@@ -218,7 +224,9 @@ fn multipointzm() -> Result<(), geozero_shp::Error> {
 fn line() -> Result<(), geozero_shp::Error> {
     let reader = geozero_shp::Reader::from_path("./tests/data/line.shp")?;
     let mut wkt_data: Vec<u8> = Vec::new();
-    reader.iter_geometries(WktWriter::new(&mut wkt_data)).next();
+    reader
+        .iter_geometries(&mut WktWriter::new(&mut wkt_data))
+        .next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTILINESTRING((1 5,5 5,5 1,3 3,1 1),(3 2,2 6))"
@@ -233,7 +241,7 @@ fn linezm() -> Result<(), geozero_shp::Error> {
     let mut writer = WktWriter::new(&mut wkt_data);
     writer.dims.z = true;
     writer.dims.m = true;
-    reader.iter_geometries(writer).next();
+    reader.iter_geometries(&mut writer).next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTILINESTRING((1 5 18 -1000000000000000000000000000000000000000,5 5 20 -1000000000000000000000000000000000000000,5 1 22 -1000000000000000000000000000000000000000,3 3 0 -1000000000000000000000000000000000000000,1 1 0 -1000000000000000000000000000000000000000),(3 2 0 -1000000000000000000000000000000000000000,2 6 0 -1000000000000000000000000000000000000000),(3 2 15 0,2 6 13 3,1 9 14 2))"
@@ -243,7 +251,7 @@ fn linezm() -> Result<(), geozero_shp::Error> {
     let mut wkt_data: Vec<u8> = Vec::new();
     let mut writer = WktWriter::new(&mut wkt_data);
     writer.dims.z = true; // return XYZ only
-    reader.iter_geometries(writer).next();
+    reader.iter_geometries(&mut writer).next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTILINESTRING((1 5 18,5 5 20,5 1 22,3 3 0,1 1 0),(3 2 0,2 6 0),(3 2 15,2 6 13,1 9 14))"
@@ -251,9 +259,9 @@ fn linezm() -> Result<(), geozero_shp::Error> {
 
     let reader = geozero_shp::Reader::from_path("./tests/data/linez.shp")?;
     let mut wkt_data: Vec<u8> = Vec::new();
-    let writer = WktWriter::new(&mut wkt_data);
+    let mut writer = WktWriter::new(&mut wkt_data);
     // return XY only
-    reader.iter_geometries(writer).next();
+    reader.iter_geometries(&mut writer).next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTILINESTRING((1 5,5 5,5 1,3 3,1 1),(3 2,2 6),(3 2,2 6,1 9))"
@@ -263,7 +271,7 @@ fn linezm() -> Result<(), geozero_shp::Error> {
     let mut wkt_data: Vec<u8> = Vec::new();
     let mut writer = WktWriter::new(&mut wkt_data);
     writer.dims.m = true;
-    reader.iter_geometries(writer).next();
+    reader.iter_geometries(&mut writer).next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTILINESTRING((1 5 0,5 5 -1000000000000000000000000000000000000000,5 1 3,3 3 -1000000000000000000000000000000000000000,1 1 0),(3 2 -1000000000000000000000000000000000000000,2 6 -1000000000000000000000000000000000000000))"
@@ -276,7 +284,9 @@ fn linezm() -> Result<(), geozero_shp::Error> {
 fn polygon() -> Result<(), geozero_shp::Error> {
     let reader = geozero_shp::Reader::from_path("./tests/data/polygon.shp")?;
     let mut wkt_data: Vec<u8> = Vec::new();
-    reader.iter_geometries(WktWriter::new(&mut wkt_data)).next();
+    reader
+        .iter_geometries(&mut WktWriter::new(&mut wkt_data))
+        .next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTIPOLYGON(((122 37,117 36,115 32,118 20,113 24)),((15 2,17 6,22 7),(122 37,117 36,115 32)))"
@@ -285,7 +295,9 @@ fn polygon() -> Result<(), geozero_shp::Error> {
 
     let reader = geozero_shp::Reader::from_path("./tests/data/polygon_hole.shp")?;
     let mut wkt_data: Vec<u8> = Vec::new();
-    reader.iter_geometries(WktWriter::new(&mut wkt_data)).next();
+    reader
+        .iter_geometries(&mut WktWriter::new(&mut wkt_data))
+        .next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTIPOLYGON(((-120 60,120 60,120 -60,-120 -60,-120 60),(-60 30,-60 -30,60 -30,60 30,-60 30)))"
@@ -293,7 +305,9 @@ fn polygon() -> Result<(), geozero_shp::Error> {
 
     let reader = geozero_shp::Reader::from_path("./tests/data/multi_polygon.shp")?;
     let mut wkt_data: Vec<u8> = Vec::new();
-    reader.iter_geometries(WktWriter::new(&mut wkt_data)).next();
+    reader
+        .iter_geometries(&mut WktWriter::new(&mut wkt_data))
+        .next();
     assert_eq!(
         &from_utf8(&wkt_data).unwrap()[0..100],
         "MULTIPOLYGON(((5.879502799999998 43.13421680053936,5.8798122999999975 43.13437570053936,5.8801381999"
@@ -312,7 +326,7 @@ fn polygonzm() -> Result<(), geozero_shp::Error> {
     let mut writer = WktWriter::new(&mut wkt_data);
     writer.dims.z = true;
     writer.dims.m = true;
-    reader.iter_geometries(writer).next();
+    reader.iter_geometries(&mut writer).next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTIPOLYGON(((1422692.1644789441 4188837.794210903 72.46632654472523 0,1422692.1625749937 4188837.75060327 72.46632654472523 1,1422692.156877633 4188837.7073275167 72.46632654472523 2,1422692.1474302218 4188837.664712999 72.46632654472523 3,1422692.1343046608 4188837.6230840385 72.46632654472523 4,1422692.1176008438 4188837.582757457 72.46632654472523 5,1422692.0974458966 4188837.5440401635 72.46632654472523 6,1422692.0739932107 4188837.5072268206 72.46632654472523 7,1422692.047421275 4188837.4725976 72.46632654472523 8,1422692.017932318 4188837.4404160506 72.46632654472523 9,1422691.9857507686 4188837.4109270936 72.46632654472523 10,1422691.951121548 4188837.384355158 72.46632654472523 11,1422691.914308205 4188837.360902472 72.46632654472523 12,1422691.8755909116 4188837.3407475245 72.46632654472523 13,1422691.8352643298 4188837.3240437075 72.46632654472523 14,1422691.7936353693 4188837.3109181467 72.46632654472523 15,1422691.7510208515 4188837.3014707356 72.46632654472523 16,1422691.7077450987 4188837.295773375 72.46632654472523 17,1422691.6641374656 4188837.293869424 72.46632654472523 18,1422691.6205298326 4188837.295773375 72.46632654472523 19,1422691.5772540797 4188837.3014707356 72.46632654472523 20,1422691.534639562 4188837.3109181467 72.46632654472523 21,1422691.4930106015 4188837.3240437075 72.46632654472523 22,1422691.4526840197 4188837.3407475245 72.46632654472523 23,1422691.4139667263 4188837.360902472 72.46632654472523 24,1422691.3771533833 4188837.384355158 72.46632654472523 25,1422691.3425241627 4188837.4109270936 72.46632654472523 26,1422691.3103426134 4188837.4404160506 72.46632654472523 27,1422691.2808536564 4188837.4725976 72.46632654472523 28,1422691.2542817206 4188837.5072268206 72.46632654472523 29,1422691.2308290347 4188837.5440401635 72.46632654472523 30,1422691.2106740875 4188837.582757457 72.46632654472523 31,1422691.1939702705 4188837.6230840385 72.46632654472523 32,1422691.1808447095 4188837.664712999 72.46632654472523 33,1422691.1713972983 4188837.7073275167 72.46632654472523 34,1422691.1656999376 4188837.75060327 72.46632654472523 35,1422691.1637959871 4188837.794210903 72.46632654472523 36,1422691.1656999376 4188837.837818536 72.46632654472523 37,1422691.1713972983 4188837.881094289 72.46632654472523 38,1422691.1808447095 4188837.9237088067 72.46632654472523 39,1422691.1939702705 4188837.9653377673 72.46632654472523 40,1422691.2106740875 4188838.0056643486 72.46632654472523 41,1422691.2308290347 4188838.0443816422 72.46632654472523 42,1422691.2542817206 4188838.081194985 72.46632654472523 43,1422691.2808536564 4188838.115824206 72.46632654472523 44,1422691.3103426134 4188838.148005755 72.46632654472523 45,1422691.3425241627 4188838.177494712 72.46632654472523 46,1422691.3771533833 4188838.2040666477 72.46632654472523 47,1422691.4139667263 4188838.227519334 72.46632654472523 48,1422691.4526840197 4188838.2476742812 72.46632654472523 49,1422691.4930106015 4188838.2643780983 72.46632654472523 50,1422691.534639562 4188838.277503659 72.46632654472523 51,1422691.5772540797 4188838.28695107 72.46632654472523 52,1422691.6205298326 4188838.292648431 72.46632654472523 53,1422691.6641374656 4188838.2945523816 72.46632654472523 54,1422691.7077450987 4188838.292648431 72.46632654472523 55,1422691.7510208515 4188838.28695107 72.46632654472523 56,1422691.7936353693 4188838.277503659 72.46632654472523 57,1422691.8352643298 4188838.2643780983 72.46632654472523 58,1422691.8755909116 4188838.2476742812 72.46632654472523 59,1422691.914308205 4188838.227519334 72.46632654472523 60,1422691.951121548 4188838.2040666477 72.46632654472523 61,1422691.9857507686 4188838.177494712 72.46632654472523 62,1422692.017932318 4188838.148005755 72.46632654472523 63,1422692.047421275 4188838.115824206 72.46632654472523 64,1422692.0739932107 4188838.081194985 72.46632654472523 65,1422692.0974458966 4188838.0443816422 72.46632654472523 66,1422692.1176008438 4188838.0056643486 72.46632654472523 67,1422692.1343046608 4188837.9653377673 72.46632654472523 68,1422692.1474302218 4188837.9237088067 72.46632654472523 69,1422692.156877633 4188837.881094289 72.46632654472523 70,1422692.1625749937 4188837.837818536 72.46632654472523 71,1422692.1644789441 4188837.794210903 72.46632654472523 72)))"
@@ -322,7 +336,7 @@ fn polygonzm() -> Result<(), geozero_shp::Error> {
     let mut wkt_data: Vec<u8> = Vec::new();
     let mut writer = WktWriter::new(&mut wkt_data);
     writer.dims.m = true;
-    reader.iter_geometries(writer).next();
+    reader.iter_geometries(&mut writer).next();
     assert_eq!(
         from_utf8(&wkt_data).unwrap(),
         "MULTIPOLYGON(((159814.75390576152 5404314.139043656 0,160420.36722814097 5403703.520652497 0,159374.30785312195 5403473.287488617 0,159814.75390576152 5404314.139043656 0)))"


### PR DESCRIPTION
This makes this code possible:

```rust
let shapefile_reader = geozero_shp::Reader::new(&mut bytes_cursor)?;
let mut geo_writer = geozero::geo_types::GeoWriter::new();
shapefile_reader.iter_geometries(&mut geo_writer);
let geometry = geo_writer.take_geometry().unwrap();
```

Previously I couldn't call `take_geometry` since the processor would move.