### PR TITLE
Resolve some default-warn clippy lints in the geozero-shp crate

### DIFF
--- a/geozero-shp/src/header.rs
+++ b/geozero-shp/src/header.rs
@@ -130,41 +130,38 @@ impl ShapeType {
 
     /// Returns whether the ShapeType has the third dimension Z
     pub fn has_z(self) -> bool {
-        match self {
-            ShapeType::PointZ
-            | ShapeType::PolylineZ
-            | ShapeType::PolygonZ
-            | ShapeType::MultipointZ => true,
-            _ => false,
-        }
+        matches!(
+            self,
+            ShapeType::PointZ | ShapeType::PolylineZ | ShapeType::PolygonZ | ShapeType::MultipointZ
+        )
     }
 
     /// Returns whether the ShapeType has the optional measure dimension
     pub fn has_m(self) -> bool {
-        match self {
+        matches!(
+            self,
             ShapeType::PointZ
-            | ShapeType::PolylineZ
-            | ShapeType::PolygonZ
-            | ShapeType::MultipointZ
-            | ShapeType::PointM
-            | ShapeType::PolylineM
-            | ShapeType::PolygonM
-            | ShapeType::MultipointM => true,
-            _ => false,
-        }
+                | ShapeType::PolylineZ
+                | ShapeType::PolygonZ
+                | ShapeType::MultipointZ
+                | ShapeType::PointM
+                | ShapeType::PolylineM
+                | ShapeType::PolygonM
+                | ShapeType::MultipointM
+        )
     }
 
     /// Returns true if the shape may have multiple parts
     pub fn is_multipart(self) -> bool {
-        match self {
+        !matches!(
+            self,
             ShapeType::Point
-            | ShapeType::PointM
-            | ShapeType::PointZ
-            | ShapeType::Multipoint
-            | ShapeType::MultipointM
-            | ShapeType::MultipointZ => false,
-            _ => true,
-        }
+                | ShapeType::PointM
+                | ShapeType::PointZ
+                | ShapeType::Multipoint
+                | ShapeType::MultipointM
+                | ShapeType::MultipointZ
+        )
     }
 }
 

--- a/geozero-shp/src/header.rs
+++ b/geozero-shp/src/header.rs
@@ -53,10 +53,12 @@ impl Header {
         let version = source.read_i32::<LittleEndian>()?;
         let shape_type = ShapeType::read_from(&mut source)?;
 
-        let mut hdr = Header::default();
-        hdr.shape_type = shape_type;
-        hdr.version = version;
-        hdr.file_length = file_length_16_bit;
+        let mut hdr = Header {
+            shape_type,
+            version,
+            file_length: file_length_16_bit,
+            ..Default::default()
+        };
 
         hdr.bbox.min.x = source.read_f64::<LittleEndian>()?;
         hdr.bbox.min.y = source.read_f64::<LittleEndian>()?;

--- a/geozero-shp/src/point_z.rs
+++ b/geozero-shp/src/point_z.rs
@@ -57,7 +57,7 @@ impl fmt::Display for PointZ {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
 pub struct BBoxZ {
     pub max: PointZ,
     pub min: PointZ,
@@ -78,14 +78,5 @@ impl BBoxZ {
 
     pub fn m_range(&self) -> [f64; 2] {
         [self.min.m(), self.max.m()]
-    }
-}
-
-impl Default for BBoxZ {
-    fn default() -> Self {
-        Self {
-            max: PointZ::default(),
-            min: PointZ::default(),
-        }
     }
 }

--- a/geozero-shp/src/reader.rs
+++ b/geozero-shp/src/reader.rs
@@ -73,10 +73,11 @@ impl<'a, P: FeatureProcessor, T: Read + Seek + 'a> Iterator for ShapeRecordItera
 
             self.shape_iter.processor.geometry_begin().ok();
         }
-        let _ = match self.shape_iter.next()? {
-            Err(e) => return Some(Err(e)),
-            Ok(_) => (),
-        };
+
+        if let Err(e) = self.shape_iter.next()? {
+            return Some(Err(e));
+        }
+
         {
             let processor = &mut self.shape_iter.processor;
             processor.geometry_end().ok();

--- a/geozero-shp/src/reader.rs
+++ b/geozero-shp/src/reader.rs
@@ -129,7 +129,7 @@ impl<T: Read + Seek> Reader<T> {
     /// Read and return _only_ the records contained in the *.dbf* file
     pub fn read_records(self) -> Result<Vec<dbase::Record>, Error> {
         let mut dbf_reader = self.dbf_reader.ok_or(Error::MissingDbf)?;
-        dbf_reader.read().or_else(|e| Err(Error::DbaseError(e)))
+        dbf_reader.read().map_err(Error::DbaseError)
     }
     ///Return the FieldInfo from the dbf file
     ///Note that the deletion flag is not included in the results

--- a/geozero-shp/src/shp_reader.rs
+++ b/geozero-shp/src/shp_reader.rs
@@ -306,8 +306,10 @@ impl MultiPartShape {
             if as_poly {
                 processor.polygon_begin(tagged, num_rings, geom_idx)?;
             }
-            let mut ring_idx = 0;
-            for start_end in self.parts_index[geom_start..=geom_end].windows(2) {
+            for (ring_idx, start_end) in self.parts_index[geom_start..=geom_end]
+                .windows(2)
+                .enumerate()
+            {
                 let (start_index, end_index) = (start_end[0], start_end[1]);
                 let num_points_in_part = end_index - start_index;
                 processor.linestring_begin(tagged, num_points_in_part, ring_idx)?;
@@ -331,7 +333,6 @@ impl MultiPartShape {
                     }
                 }
                 processor.linestring_end(tagged, ring_idx)?;
-                ring_idx += 1;
             }
             if as_poly {
                 processor.polygon_end(tagged, geom_idx)?;

--- a/geozero-shp/src/shp_reader.rs
+++ b/geozero-shp/src/shp_reader.rs
@@ -158,8 +158,8 @@ fn read_multipoint<P: GeomProcessor, T: Read>(
     };
 
     let multi_dim = processor.multi_dim();
-    let get_z = processor.dimensions().z && z_values.len() > 0;
-    let get_m = processor.dimensions().m && m_values.len() > 0;
+    let get_z = processor.dimensions().z && !z_values.is_empty();
+    let get_m = processor.dimensions().m && !m_values.is_empty();
 
     processor.multipoint_begin(num_points, 0)?;
     for idx in 0..num_points {
@@ -286,8 +286,8 @@ impl MultiPartShape {
     fn process<P: GeomProcessor>(&self, processor: &mut P, as_poly: bool) -> Result<(), Error> {
         let tagged = false;
         let multi_dim = processor.dimensions().z || processor.dimensions().m;
-        let get_z = processor.dimensions().z && self.z_values.len() > 0;
-        let get_m = processor.dimensions().m && self.m_values.len() > 0;
+        let get_z = processor.dimensions().z && !self.z_values.is_empty();
+        let get_m = processor.dimensions().m && !self.m_values.is_empty();
 
         let geom_parts_indices = if as_poly {
             self.detect_polys()


### PR DESCRIPTION
Some of the code of the `geozero-shp` crate was copied over from `shapefile-rs` in 08ef12816e3f3aa2b4a5b148b22927f1399cd0c6. As-is, that code has some clippy warnings in the `clippy::all` set. This makes hacking on the geozero-shp crate a bit cumbersome, as it's hard to just call `cargo clippy` and know whether your changes introduced new clippy lints.

The changes in this PR seem to — for the most part, at least — apply to those parts that were copied over. I didn't individually git-blame to verify this, but I didn't encounter anything geozero-specific in the changes I made.

I also intentionally kept this PR _very_ sparse (only making minimal changes so as to resolve clippy lints). I aim to follow up with another PR that does more cleanup, hopefully to include some more intense refactoring and full documentation.