### PR TITLE
More Clippy Fixes, Run Clippy in CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -47,6 +47,12 @@ jobs:
           command: check
           args: --workspace --all-features --bins --examples --tests --benches
 
+      - name: run clippy
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --workspace --all-features --bins --examples --tests --benches
+
       - name: tests
         run: |
           cargo test --workspace --all-features

--- a/geozero-cli/src/main.rs
+++ b/geozero-cli/src/main.rs
@@ -39,7 +39,7 @@ pub struct Extent {
 
 fn parse_extent(src: &str) -> std::result::Result<Extent, ParseFloatError> {
     let arr: Vec<f64> = src
-        .split(",")
+        .split(',')
         .map(|v| {
             v.parse()
                 .expect("Error parsing 'extent' as list of float values")

--- a/geozero-shp/tests/reader.rs
+++ b/geozero-shp/tests/reader.rs
@@ -117,7 +117,7 @@ fn property_access() -> Result<(), geozero_shp::Error> {
             }
             // Use String HashMap
             let props = feat.properties()?;
-            assert!(props["EAS_ID"].starts_with("1"));
+            assert!(props["EAS_ID"].starts_with('1'));
             // field access
             assert!(feat.property::<f64>("EAS_ID").unwrap() > 100.0);
         } else {

--- a/geozero-shp/tests/reader.rs
+++ b/geozero-shp/tests/reader.rs
@@ -83,7 +83,7 @@ fn shp_to_geo() -> Result<(), geozero_shp::Error> {
     {
         assert_eq!(gc.len(), 10);
     } else {
-        assert!(false, "unexpected geometry");
+        panic!("unexpected geometry");
     }
 
     Ok(())
@@ -113,7 +113,7 @@ fn property_access() -> Result<(), geozero_shp::Error> {
             if let Some(FieldValue::Numeric(Some(val))) = feat.record.get("EAS_ID") {
                 assert!(*val > 100.0);
             } else {
-                assert!(false, "record field access failed");
+                panic!("record field access failed");
             }
             // Use String HashMap
             let props = feat.properties()?;
@@ -121,7 +121,7 @@ fn property_access() -> Result<(), geozero_shp::Error> {
             // field access
             assert!(feat.property::<f64>("EAS_ID").unwrap() > 100.0);
         } else {
-            assert!(false, "record field access failed");
+            panic!("record field access failed");
         }
         cnt += 1;
     }

--- a/geozero/.clippy.toml
+++ b/geozero/.clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 8

--- a/geozero/src/csv/csv_reader.rs
+++ b/geozero/src/csv/csv_reader.rs
@@ -122,7 +122,7 @@ pub fn process_csv_geom(
             .get(geometry_idx)
             .ok_or(GeozeroError::ColumnNotFound)?;
         use std::str::FromStr;
-        let wkt = wkt::Wkt::from_str(&geometry_field)
+        let wkt = wkt::Wkt::from_str(geometry_field)
             .map_err(|e| GeozeroError::Geometry(e.to_string()))?;
         crate::wkt::wkt_reader::process_wkt_geom_n(&wkt.item, record_idx, processor).map_err(
             |e| {

--- a/geozero/src/csv/csv_writer.rs
+++ b/geozero/src/csv/csv_writer.rs
@@ -511,7 +511,7 @@ POINT(1 45),904 7th Av,05/22/2019 12:55:00 PM,F190051945,Car Fire
 "POLYGON((3 1,3 2,3 1))",Bar
 "#;
 
-        let actual_output = crate::geojson::GeoJson(&input_geojson).to_csv().unwrap();
+        let actual_output = crate::geojson::GeoJson(input_geojson).to_csv().unwrap();
 
         assert_eq!(expected_output, actual_output);
     }

--- a/geozero/src/gdal/gdal_writer.rs
+++ b/geozero/src/gdal/gdal_writer.rs
@@ -23,7 +23,7 @@ impl<'a> GdalWriter {
         &self.geom
     }
     fn wkb_type(&mut self, base: OGRwkbGeometryType::Type) -> OGRwkbGeometryType::Type {
-        let mut type_id = base as u32;
+        let mut type_id = base;
         if self.dims.z {
             type_id += 1000;
         }
@@ -38,7 +38,7 @@ impl<'a> GdalWriter {
 }
 
 fn wkb_base_type(wkb_type: OGRwkbGeometryType::Type) -> OGRwkbGeometryType::Type {
-    (wkb_type as u32) % 1000
+    wkb_type % 1000
 }
 
 impl From<gdal::errors::GdalError> for GeozeroError {

--- a/geozero/src/gdal/gdal_writer.rs
+++ b/geozero/src/gdal/gdal_writer.rs
@@ -11,7 +11,7 @@ pub struct GdalWriter {
     line: Geometry,
 }
 
-impl<'a> GdalWriter {
+impl GdalWriter {
     pub fn new() -> Self {
         GdalWriter {
             dims: CoordDimensions::default(),

--- a/geozero/src/gdal/gdal_writer.rs
+++ b/geozero/src/gdal/gdal_writer.rs
@@ -13,11 +13,7 @@ pub struct GdalWriter {
 
 impl GdalWriter {
     pub fn new() -> Self {
-        GdalWriter {
-            dims: CoordDimensions::default(),
-            geom: Geometry::empty(OGRwkbGeometryType::wkbPoint).unwrap(),
-            line: Geometry::empty(OGRwkbGeometryType::wkbLineString).unwrap(),
-        }
+        Default::default()
     }
     pub fn geometry(&self) -> &Geometry {
         &self.geom
@@ -34,6 +30,16 @@ impl GdalWriter {
     }
     fn empty_geom(&mut self, base: OGRwkbGeometryType::Type) -> Result<Geometry> {
         Geometry::empty(self.wkb_type(base)).map_err(|e| e.into())
+    }
+}
+
+impl Default for GdalWriter {
+    fn default() -> Self {
+        GdalWriter {
+            dims: CoordDimensions::default(),
+            geom: Geometry::empty(OGRwkbGeometryType::wkbPoint).unwrap(),
+            line: Geometry::empty(OGRwkbGeometryType::wkbLineString).unwrap(),
+        }
     }
 }
 

--- a/geozero/src/geo_types/geo_types_reader.rs
+++ b/geozero/src/geo_types/geo_types_reader.rs
@@ -46,21 +46,21 @@ fn process_geom_n<P: GeomProcessor>(
         Geometry::MultiLineString(ref geom) => {
             processor.multilinestring_begin(geom.0.len(), idx)?;
             for (i, line) in geom.0.iter().enumerate() {
-                process_linestring(&line, false, i, processor)?;
+                process_linestring(line, false, i, processor)?;
             }
             processor.multilinestring_end(idx)?;
         }
         Geometry::MultiPolygon(ref geom) => {
             processor.multipolygon_begin(geom.0.len(), idx)?;
             for (i, poly) in geom.0.iter().enumerate() {
-                process_polygon(&poly, false, i, processor)?;
+                process_polygon(poly, false, i, processor)?;
             }
             processor.multipolygon_end(idx)?;
         }
         Geometry::GeometryCollection(ref geom) => {
             processor.geometrycollection_begin(geom.0.len(), idx)?;
             for (i, g) in geom.0.iter().enumerate() {
-                process_geom_n(&g, i, processor)?;
+                process_geom_n(g, i, processor)?;
             }
             processor.geometrycollection_end(idx)?;
         }
@@ -114,10 +114,10 @@ fn process_polygon<P: GeomProcessor>(
     let interiors = geom.interiors();
     processor.polygon_begin(tagged, interiors.len() + 1, idx)?;
     // Exterior ring
-    process_linestring(&geom.exterior(), false, 0, processor)?;
+    process_linestring(geom.exterior(), false, 0, processor)?;
     // Interior rings
     for (i, ring) in interiors.iter().enumerate() {
-        process_linestring(&ring, false, i + 1, processor)?;
+        process_linestring(ring, false, i + 1, processor)?;
     }
     processor.polygon_end(tagged, idx)
 }

--- a/geozero/src/geo_types/geo_types_reader.rs
+++ b/geozero/src/geo_types/geo_types_reader.rs
@@ -75,7 +75,7 @@ fn process_geom_n<P: GeomProcessor>(
 }
 
 fn process_coord<P: GeomProcessor>(
-    coord: &Coordinate<f64>,
+    coord: &Coord<f64>,
     idx: usize,
     processor: &mut P,
 ) -> Result<()> {

--- a/geozero/src/geo_types/geo_types_writer.rs
+++ b/geozero/src/geo_types/geo_types_writer.rs
@@ -4,6 +4,7 @@ use geo_types::*;
 use std::mem;
 
 /// Generator for geo-types geometry type.
+#[derive(Default)]
 pub struct GeoWriter {
     geoms: Vec<Geometry<f64>>,
     // Stack of any in-progress (potentially nested) GeometryCollections
@@ -18,13 +19,7 @@ pub struct GeoWriter {
 
 impl GeoWriter {
     pub fn new() -> GeoWriter {
-        GeoWriter {
-            geoms: Vec::new(),
-            coords: None,
-            line_strings: None,
-            polygons: None,
-            collections: Vec::new(),
-        }
+        Default::default()
     }
 
     pub fn take_geometry(&mut self) -> Option<Geometry<f64>> {

--- a/geozero/src/geo_types/geo_types_writer.rs
+++ b/geozero/src/geo_types/geo_types_writer.rs
@@ -14,7 +14,7 @@ pub struct GeoWriter {
     // In-progress polygon or multi_linestring
     line_strings: Option<Vec<LineString<f64>>>,
     // In-progress point or line_string
-    coords: Option<Vec<Coordinate<f64>>>,
+    coords: Option<Vec<Coord<f64>>>,
 }
 
 impl GeoWriter {

--- a/geozero/src/geo_types/geo_types_writer.rs
+++ b/geozero/src/geo_types/geo_types_writer.rs
@@ -135,7 +135,7 @@ impl GeomProcessor for GeoWriter {
             "Missing LineStrings for Polygon".to_string(),
         ))?;
 
-        let polygon = if line_strings.len() == 0 {
+        let polygon = if line_strings.is_empty() {
             Polygon::new(LineString(vec![]), vec![])
         } else {
             let exterior = line_strings.remove(0);
@@ -220,7 +220,7 @@ mod test {
         println!("{:?}", geo);
         match geo {
             Geometry::MultiPolygon(mp) => {
-                let poly = mp.clone().into_iter().next().unwrap();
+                let poly = mp.into_iter().next().unwrap();
                 assert_eq!(
                     poly.exterior().points().next().unwrap(),
                     Point::new(173.020375, -40.919052)

--- a/geozero/src/geo_types/geo_types_writer.rs
+++ b/geozero/src/geo_types/geo_types_writer.rs
@@ -201,7 +201,7 @@ mod test {
                     Point::new(1875038.447610231, -3269648.6879248763)
                 );
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
         Ok(())
     }
@@ -221,7 +221,7 @@ mod test {
                     Point::new(173.020375, -40.919052)
                 );
             }
-            _ => assert!(false),
+            _ => unreachable!(),
         }
         Ok(())
     }

--- a/geozero/src/geojson/geojson_reader.rs
+++ b/geozero/src/geojson/geojson_reader.rs
@@ -58,11 +58,10 @@ pub fn read_geojson<R: Read, P: FeatureProcessor>(mut reader: R, processor: &mut
 }
 
 pub fn read_geojson_fc<R: Read, P: FeatureProcessor>(reader: R, processor: &mut P) -> Result<()> {
-    let mut idx = 0;
-    for feature in FeatureReader::from_reader(reader).features() {
+    for (idx, feature) in FeatureReader::from_reader(reader).features().enumerate() {
         process_geojson_feature(&feature?, idx, processor)?;
-        idx += 1;
     }
+
     Ok(())
 }
 

--- a/geozero/src/geojson/geojson_reader.rs
+++ b/geozero/src/geojson/geojson_reader.rs
@@ -201,19 +201,19 @@ fn process_properties<P: PropertyProcessor>(
     for (i, (key, value)) in properties.iter().enumerate() {
         // Could we provide a stable property index?
         match value {
-            JsonValue::String(v) => processor.property(i, &key, &ColumnValue::String(v))?,
+            JsonValue::String(v) => processor.property(i, key, &ColumnValue::String(v))?,
             JsonValue::Number(v) if v.is_f64() => {
-                processor.property(i, &key, &ColumnValue::Double(v.as_f64().unwrap()))?
+                processor.property(i, key, &ColumnValue::Double(v.as_f64().unwrap()))?
             }
             JsonValue::Number(v) if v.is_i64() => {
-                processor.property(i, &key, &ColumnValue::Long(v.as_i64().unwrap()))?
+                processor.property(i, key, &ColumnValue::Long(v.as_i64().unwrap()))?
             }
             JsonValue::Number(v) if v.is_u64() => {
-                processor.property(i, &key, &ColumnValue::ULong(v.as_u64().unwrap()))?
+                processor.property(i, key, &ColumnValue::ULong(v.as_u64().unwrap()))?
             }
-            JsonValue::Bool(v) => processor.property(i, &key, &ColumnValue::Bool(*v))?,
+            JsonValue::Bool(v) => processor.property(i, key, &ColumnValue::Bool(*v))?,
             // Null, Array(Vec<Value>), Object(Map<String, Value>)
-            _ => processor.property(i, &key, &ColumnValue::String(&value.to_string()))?,
+            _ => processor.property(i, key, &ColumnValue::String(&value.to_string()))?,
         };
     }
     Ok(())
@@ -234,7 +234,7 @@ fn process_coord<P: GeomProcessor>(
         processor.coordinate(
             point_type[0],
             point_type[1],
-            point_type.get(2).map(|v| *v),
+            point_type.get(2).copied(),
             None,
             None,
             None,
@@ -289,7 +289,7 @@ fn process_multilinestring<P: GeomProcessor>(
 ) -> Result<()> {
     processor.multilinestring_begin(multilinestring_type.len(), idx)?;
     for (idxc, linestring_type) in multilinestring_type.iter().enumerate() {
-        process_linestring(&linestring_type, false, idxc, processor)?
+        process_linestring(linestring_type, false, idxc, processor)?
     }
     processor.multilinestring_end(idx)
 }
@@ -314,7 +314,7 @@ fn process_multi_polygon<P: GeomProcessor>(
 ) -> Result<()> {
     processor.multipolygon_begin(multi_polygon_type.len(), idx)?;
     for (idxp, polygon_type) in multi_polygon_type.iter().enumerate() {
-        process_polygon(&polygon_type, false, idxp, processor)?;
+        process_polygon(polygon_type, false, idxp, processor)?;
     }
     processor.multipolygon_end(idx)
 }

--- a/geozero/src/geojson/geojson_writer.rs
+++ b/geozero/src/geojson/geojson_writer.rs
@@ -77,7 +77,7 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
     }
     fn xy(&mut self, x: f64, y: f64, idx: usize) -> Result<()> {
         self.comma(idx)?;
-        self.out.write_all(&format!("[{},{}]", x, y).as_bytes())?;
+        self.out.write_all(format!("[{},{}]", x, y).as_bytes())?;
         Ok(())
     }
     fn coordinate(
@@ -91,9 +91,9 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
         idx: usize,
     ) -> Result<()> {
         self.comma(idx)?;
-        self.out.write_all(&format!("[{},{}", x, y).as_bytes())?;
+        self.out.write_all(format!("[{},{}", x, y).as_bytes())?;
         if let Some(z) = z {
-            self.out.write_all(&format!(",{}", z).as_bytes())?;
+            self.out.write_all(format!(",{}", z).as_bytes())?;
         }
         self.out.write_all(b"]")?;
         Ok(())
@@ -187,16 +187,16 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
 }
 
 fn write_num_prop<'a, W: Write>(out: &'a mut W, colname: &str, v: &dyn Display) -> Result<()> {
-    out.write_all(&format!(r#""{}": {v}"#, colname.replace("\"", "\\\"")).as_bytes())?;
+    out.write_all(format!(r#""{}": {v}"#, colname.replace('\"', "\\\"")).as_bytes())?;
     Ok(())
 }
 
 fn write_str_prop<'a, W: Write>(out: &'a mut W, colname: &str, v: &str) -> Result<()> {
     out.write_all(
-        &format!(
+        format!(
             r#""{}": "{}""#,
-            colname.replace("\"", "\\\""),
-            v.replace("\"", "\\\"")
+            colname.replace('\"', "\\\""),
+            v.replace('\"', "\\\"")
         )
         .as_bytes(),
     )?;
@@ -220,9 +220,9 @@ impl<W: Write> PropertyProcessor for GeoJsonWriter<'_, W> {
             ColumnValue::ULong(v) => write_num_prop(self.out, colname, &v)?,
             ColumnValue::Float(v) => write_num_prop(self.out, colname, &v)?,
             ColumnValue::Double(v) => write_num_prop(self.out, colname, &v)?,
-            ColumnValue::String(v) => write_str_prop(self.out, colname, &v)?,
+            ColumnValue::String(v) => write_str_prop(self.out, colname, v)?,
             ColumnValue::Json(_v) => (),
-            ColumnValue::DateTime(v) => write_str_prop(self.out, colname, &v)?,
+            ColumnValue::DateTime(v) => write_str_prop(self.out, colname, v)?,
             ColumnValue::Binary(_v) => (),
         };
         Ok(false)

--- a/geozero/src/geojson/geojson_writer.rs
+++ b/geozero/src/geojson/geojson_writer.rs
@@ -186,12 +186,12 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
     }
 }
 
-fn write_num_prop<'a, W: Write>(out: &'a mut W, colname: &str, v: &dyn Display) -> Result<()> {
+fn write_num_prop<W: Write>(out: &mut W, colname: &str, v: &dyn Display) -> Result<()> {
     out.write_all(format!(r#""{}": {v}"#, colname.replace('\"', "\\\"")).as_bytes())?;
     Ok(())
 }
 
-fn write_str_prop<'a, W: Write>(out: &'a mut W, colname: &str, v: &str) -> Result<()> {
+fn write_str_prop<W: Write>(out: &mut W, colname: &str, v: &str) -> Result<()> {
     out.write_all(
         format!(
             r#""{}": "{}""#,

--- a/geozero/src/geos/geos_writer.rs
+++ b/geozero/src/geos/geos_writer.rs
@@ -101,7 +101,7 @@ impl GeomProcessor for GeosWriter<'_> {
         let gglines = self
             .cs
             .drain(..)
-            .map(|cs| GGeometry::create_line_string(cs))
+            .map(GGeometry::create_line_string)
             .collect::<GResult<Vec<GGeometry>>>()?;
         self.geom = GGeometry::create_multiline_string(gglines)?;
         Ok(())
@@ -120,7 +120,7 @@ impl GeomProcessor for GeosWriter<'_> {
         let interiors = self
             .cs
             .drain(..)
-            .map(|cs| GGeometry::create_linear_ring(cs))
+            .map(GGeometry::create_linear_ring)
             .collect::<GResult<Vec<GGeometry>>>()?;
         let gpoly = GGeometry::create_polygon(exterior_ring, interiors)?;
         if tagged {

--- a/geozero/src/geos/geos_writer.rs
+++ b/geozero/src/geos/geos_writer.rs
@@ -13,11 +13,7 @@ pub struct GeosWriter<'a> {
 
 impl<'a> GeosWriter<'a> {
     pub fn new() -> Self {
-        GeosWriter {
-            geom: GGeometry::create_empty_point().unwrap(),
-            cs: Vec::new(),
-            polys: Vec::new(),
-        }
+        Default::default()
     }
     fn add_coord_seq(&mut self, len: usize) -> Result<()> {
         self.cs
@@ -26,6 +22,16 @@ impl<'a> GeosWriter<'a> {
     }
     pub fn geometry(&self) -> &GGeometry<'a> {
         &self.geom
+    }
+}
+
+impl<'a> Default for GeosWriter<'a> {
+    fn default() -> Self {
+        GeosWriter {
+            geom: GGeometry::create_empty_point().unwrap(),
+            cs: Vec::new(),
+            polys: Vec::new(),
+        }
     }
 }
 

--- a/geozero/src/lib.rs
+++ b/geozero/src/lib.rs
@@ -109,11 +109,12 @@ pub mod mvt;
 pub use crate::mvt::conversion::*;
 
 /// Empty processor implementation
+#[derive(Default)]
 pub struct ProcessorSink;
 
 impl ProcessorSink {
     pub fn new() -> ProcessorSink {
-        ProcessorSink {}
+        Default::default()
     }
 }
 

--- a/geozero/src/mvt/mvt_reader.rs
+++ b/geozero/src/mvt/mvt_reader.rs
@@ -191,8 +191,8 @@ fn process_linestrings<P: GeomProcessor>(
 
     if line_string_slices.len() > 1 {
         processor.multilinestring_begin(line_string_slices.len(), idx)?;
-        for i in 0..line_string_slices.len() {
-            process_linestring(cursor, line_string_slices[i], false, i, processor)?;
+        for (i, line_string_slice) in line_string_slices.iter().enumerate() {
+            process_linestring(cursor, line_string_slice, false, i, processor)?;
         }
         processor.multilinestring_end(idx)?;
     } else {
@@ -274,8 +274,8 @@ fn process_polygons<P: GeomProcessor>(
 
     if polygon_slices.len() > 1 {
         processor.multipolygon_begin(polygon_slices.len(), idx)?;
-        for i in 0..polygon_slices.len() {
-            process_polygon(cursor, &polygon_slices[i], false, i, processor)?;
+        for (i, polygon_slice) in polygon_slices.iter().enumerate() {
+            process_polygon(cursor, polygon_slice, false, i, processor)?;
         }
         processor.multipolygon_end(idx)?;
     } else {

--- a/geozero/src/mvt/mvt_reader.rs
+++ b/geozero/src/mvt/mvt_reader.rs
@@ -314,10 +314,12 @@ mod test {
     #[test]
     fn layer() {
         // https://github.com/mapbox/vector-tile-spec/tree/master/2.1#45-example
-        let mut mvt_layer = tile::Layer::default();
-        mvt_layer.version = 2;
-        mvt_layer.name = String::from("points");
-        mvt_layer.extent = Some(4096);
+        let mut mvt_layer = tile::Layer {
+            version: 2,
+            name: String::from("points"),
+            extent: Some(4096),
+            ..Default::default()
+        };
 
         mvt_layer.keys.push(String::from("hello"));
         mvt_layer.keys.push(String::from("h"));
@@ -341,20 +343,24 @@ mod test {
         });
 
         {
-            let mut mvt_feature = tile::Feature::default();
-            mvt_feature.id = Some(1);
+            let mut mvt_feature = tile::Feature {
+                id: Some(1),
+                tags: [0, 0, 1, 0, 2, 1].to_vec(),
+                geometry: [9, 2410, 3080].to_vec(),
+                ..Default::default()
+            };
             mvt_feature.set_type(GeomType::Point);
-            mvt_feature.tags = [0, 0, 1, 0, 2, 1].to_vec();
-            mvt_feature.geometry = [9, 2410, 3080].to_vec();
             mvt_layer.features.push(mvt_feature);
         }
 
         {
-            let mut mvt_feature = tile::Feature::default();
-            mvt_feature.id = Some(2);
+            let mut mvt_feature = tile::Feature {
+                id: Some(2),
+                tags: [0, 2, 2, 3].to_vec(),
+                geometry: [9, 2410, 3080].to_vec(),
+                ..Default::default()
+            };
             mvt_feature.set_type(GeomType::Point);
-            mvt_feature.tags = [0, 2, 2, 3].to_vec();
-            mvt_feature.geometry = [9, 2410, 3080].to_vec();
             mvt_layer.features.push(mvt_feature);
         }
 

--- a/geozero/src/mvt/mvt_writer.rs
+++ b/geozero/src/mvt/mvt_writer.rs
@@ -153,7 +153,7 @@ mod test_mvt {
     use crate::mvt::vector_tile::Tile;
 
     // https://github.com/mapbox/vector-tile-spec/tree/master/2.1#45-example
-    const TILE_EXAMPLE: &'static str = r#"Tile {
+    const TILE_EXAMPLE: &str = r#"Tile {
     layers: [
         Layer {
             version: 2,

--- a/geozero/src/mvt/mvt_writer.rs
+++ b/geozero/src/mvt/mvt_writer.rs
@@ -25,13 +25,7 @@ enum LineState {
 
 impl MvtWriter {
     pub fn new() -> MvtWriter {
-        MvtWriter {
-            feature: tile::Feature::default(),
-            last_x: 0,
-            last_y: 0,
-            line_state: LineState::None,
-            is_multiline: false,
-        }
+        Default::default()
     }
     pub fn geometry(&self) -> &tile::Feature {
         &self.feature
@@ -42,6 +36,18 @@ impl MvtWriter {
             self.feature
                 .geometry
                 .reserve(total - self.feature.geometry.capacity());
+        }
+    }
+}
+
+impl Default for MvtWriter {
+    fn default() -> Self {
+        Self {
+            feature: tile::Feature::default(),
+            last_x: 0,
+            last_y: 0,
+            line_state: LineState::None,
+            is_multiline: false,
         }
     }
 }

--- a/geozero/src/mvt/mvt_writer.rs
+++ b/geozero/src/mvt/mvt_writer.rs
@@ -263,25 +263,33 @@ mod test_mvt {
         // https://github.com/mapbox/vector-tile-spec/tree/master/2.1#45-example
         let mut mvt_tile = Tile::default();
 
-        let mut mvt_layer = tile::Layer::default();
-        mvt_layer.version = 2;
+        let mut mvt_layer = tile::Layer {
+            version: 2,
+            ..Default::default()
+        };
         mvt_layer.name = String::from("points");
         mvt_layer.extent = Some(4096);
 
-        let mut mvt_feature = tile::Feature::default();
-        mvt_feature.id = Some(1);
+        let mut mvt_feature = tile::Feature {
+            id: Some(1),
+            ..Default::default()
+        };
         mvt_feature.set_type(GeomType::Point);
         mvt_feature.geometry = [9, 490, 6262].to_vec();
 
-        let mut mvt_value = tile::Value::default();
-        mvt_value.string_value = Some(String::from("world"));
+        let mvt_value = tile::Value {
+            string_value: Some(String::from("world")),
+            ..Default::default()
+        };
         add_feature_attribute(
             &mut mvt_layer,
             &mut mvt_feature,
             String::from("hello"),
             mvt_value,
         );
-        let mut mvt_value = tile::Value::default();
+        let mut mvt_value = tile::Value {
+            ..Default::default()
+        };
         mvt_value.string_value = Some(String::from("world"));
         add_feature_attribute(
             &mut mvt_layer,
@@ -289,8 +297,10 @@ mod test_mvt {
             String::from("h"),
             mvt_value,
         );
-        let mut mvt_value = tile::Value::default();
-        mvt_value.double_value = Some(1.23);
+        let mvt_value = tile::Value {
+            double_value: Some(1.23),
+            ..Default::default()
+        };
         add_feature_attribute(
             &mut mvt_layer,
             &mut mvt_feature,
@@ -305,16 +315,20 @@ mod test_mvt {
         mvt_feature.set_type(GeomType::Point);
         mvt_feature.geometry = [9, 490, 6262].to_vec();
 
-        let mut mvt_value = tile::Value::default();
-        mvt_value.string_value = Some(String::from("again"));
+        let mvt_value = tile::Value {
+            string_value: Some(String::from("again")),
+            ..Default::default()
+        };
         add_feature_attribute(
             &mut mvt_layer,
             &mut mvt_feature,
             String::from("hello"),
             mvt_value,
         );
-        let mut mvt_value = tile::Value::default();
-        mvt_value.int_value = Some(2);
+        let mvt_value = tile::Value {
+            int_value: Some(2),
+            ..Default::default()
+        };
         add_feature_attribute(
             &mut mvt_layer,
             &mut mvt_feature,

--- a/geozero/src/mvt/vector_tile.rs
+++ b/geozero/src/mvt/vector_tile.rs
@@ -108,5 +108,15 @@ pub mod tile {
                 GeomType::Polygon => "POLYGON",
             }
         }
+        /// Creates an enum from field names used in the ProtoBuf definition.
+        pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+            match value {
+                "UNKNOWN" => Some(Self::Unknown),
+                "POINT" => Some(Self::Point),
+                "LINESTRING" => Some(Self::Linestring),
+                "POLYGON" => Some(Self::Polygon),
+                _ => None,
+            }
+        }
     }
 }

--- a/geozero/src/postgis/postgis_postgres.rs
+++ b/geozero/src/postgis/postgis_postgres.rs
@@ -24,7 +24,7 @@ impl<T: FromWkb + Sized> FromSql<'_> for wkb::Decode<T> {
     }
 }
 
-impl<'a, T: GeozeroGeometry + Sized> ToSql for wkb::Encode<T> {
+impl<T: GeozeroGeometry + Sized> ToSql for wkb::Encode<T> {
     fn to_sql(
         &self,
         _ty: &Type,

--- a/geozero/src/postgis/postgis_postgres.rs
+++ b/geozero/src/postgis/postgis_postgres.rs
@@ -17,10 +17,7 @@ impl<T: FromWkb + Sized> FromSql<'_> for wkb::Decode<T> {
     }
 
     fn accepts(ty: &Type) -> bool {
-        match ty.name() {
-            "geography" | "geometry" => true,
-            _ => false,
-        }
+        matches!(ty.name(), "geography" | "geometry")
     }
 }
 
@@ -39,10 +36,7 @@ impl<T: GeozeroGeometry + Sized> ToSql for wkb::Encode<T> {
     }
 
     fn accepts(ty: &Type) -> bool {
-        match ty.name() {
-            "geography" | "geometry" => true,
-            _ => false,
-        }
+        matches!(ty.name(), "geography" | "geometry")
     }
 
     to_sql_checked!();

--- a/geozero/src/svg/mod.rs
+++ b/geozero/src/svg/mod.rs
@@ -1,10 +1,12 @@
 //! SVG conversions.
-mod svg;
+mod writer;
+pub use writer::SvgWriter;
 
-pub use svg::*;
+/// SVG String.
+pub struct SvgString(pub String);
 
 pub(crate) mod conversion {
-    use super::svg::*;
+    use super::*;
     use crate::error::Result;
     use crate::FeatureProcessor;
     use crate::{GeozeroDatasource, GeozeroGeometry};
@@ -80,7 +82,7 @@ pub(crate) mod conversion {
 
 #[cfg(feature = "with-wkb")]
 mod wkb {
-    use super::svg::*;
+    use super::*;
     use crate::error::Result;
     use crate::wkb::{FromWkb, WkbDialect};
     use std::io::Read;

--- a/geozero/src/svg/svg.rs
+++ b/geozero/src/svg/svg.rs
@@ -48,11 +48,11 @@ impl<W: Write> FeatureProcessor for SvgWriter<'_, W> {
         )?;
         if let Some((width, height)) = self.size {
             self.out
-                .write_all(&format!("width=\"{}\" height=\"{}\" ", width, height).as_bytes())?;
+                .write_all(format!("width=\"{}\" height=\"{}\" ", width, height).as_bytes())?;
         }
         if let Some((xmin, ymin, xmax, ymax)) = self.view_box {
             self.out.write_all(
-                &format!(
+                format!(
                     "viewBox=\"{} {} {} {}\" ",
                     xmin,
                     ymin,
@@ -88,7 +88,7 @@ impl<W: Write> FeatureProcessor for SvgWriter<'_, W> {
 impl<W: Write> GeomProcessor for SvgWriter<'_, W> {
     fn xy(&mut self, x: f64, y: f64, _idx: usize) -> Result<()> {
         let y = if self.invert_y { -y } else { y };
-        self.out.write_all(&format!("{} {} ", x, y).as_bytes())?;
+        self.out.write_all(format!("{} {} ", x, y).as_bytes())?;
         Ok(())
     }
     fn point_begin(&mut self, _idx: usize) -> Result<()> {

--- a/geozero/src/svg/writer.rs
+++ b/geozero/src/svg/writer.rs
@@ -2,9 +2,6 @@ use crate::error::Result;
 use crate::{FeatureProcessor, GeomProcessor, PropertyProcessor};
 use std::io::Write;
 
-/// SVG String.
-pub struct SvgString(pub String);
-
 /// SVG writer.
 pub struct SvgWriter<'a, W: Write> {
     out: &'a mut W,

--- a/geozero/src/wkb/wkb_common.rs
+++ b/geozero/src/wkb/wkb_common.rs
@@ -15,7 +15,7 @@ pub struct Decode<T: FromWkb> {
 }
 
 // required by postgres ToSql
-impl<'a, T: GeozeroGeometry + Sized> fmt::Debug for Encode<T> {
+impl<T: GeozeroGeometry + Sized> fmt::Debug for Encode<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.0.to_wkt().unwrap_or("<unkown geometry>".to_string()))
     }

--- a/geozero/src/wkb/wkb_common.rs
+++ b/geozero/src/wkb/wkb_common.rs
@@ -195,6 +195,6 @@ impl WKBGeometryType {
 }
 
 pub(crate) enum WKBByteOrder {
-    XDR = 0, // Big Endian
-    NDR = 1, // Little Endian
+    Xdr = 0, // Big Endian
+    Ndr = 1, // Little Endian
 }

--- a/geozero/src/wkb/wkb_reader.rs
+++ b/geozero/src/wkb/wkb_reader.rs
@@ -198,7 +198,7 @@ pub(crate) fn process_wkb_geom_n<R: Read, P: GeomProcessor>(
     match info.base_type {
         WKBGeometryType::Point => {
             processor.point_begin(idx)?;
-            process_coord(raw, &info, processor.multi_dim(), 0, processor)?;
+            process_coord(raw, info, processor.multi_dim(), 0, processor)?;
             processor.point_end(idx)?;
         }
         WKBGeometryType::MultiPoint => {
@@ -212,13 +212,13 @@ pub(crate) fn process_wkb_geom_n<R: Read, P: GeomProcessor>(
             processor.multipoint_end(idx)?;
         }
         WKBGeometryType::LineString => {
-            process_linestring(raw, &info, true, idx, processor)?;
+            process_linestring(raw, info, true, idx, processor)?;
         }
         WKBGeometryType::CircularString => {
-            process_circularstring(raw, &info, idx, processor)?;
+            process_circularstring(raw, info, idx, processor)?;
         }
         WKBGeometryType::CompoundCurve => {
-            process_compoundcurve(raw, &info, read_header, idx, processor)?;
+            process_compoundcurve(raw, info, read_header, idx, processor)?;
         }
         WKBGeometryType::MultiLineString => {
             let n_lines = raw.ioread_with::<u32>(info.endian)? as usize;
@@ -238,13 +238,13 @@ pub(crate) fn process_wkb_geom_n<R: Read, P: GeomProcessor>(
             processor.multicurve_end(idx)?;
         }
         WKBGeometryType::Polygon => {
-            process_polygon(raw, &info, true, idx, processor)?;
+            process_polygon(raw, info, true, idx, processor)?;
         }
         WKBGeometryType::Triangle => {
-            process_triangle(raw, &info, true, idx, processor)?;
+            process_triangle(raw, info, true, idx, processor)?;
         }
         WKBGeometryType::CurvePolygon => {
-            process_curvepolygon(raw, &info, read_header, idx, processor)?;
+            process_curvepolygon(raw, info, read_header, idx, processor)?;
         }
         WKBGeometryType::MultiPolygon => {
             let n_polys = raw.ioread_with::<u32>(info.endian)? as usize;

--- a/geozero/src/wkb/wkb_reader.rs
+++ b/geozero/src/wkb/wkb_reader.rs
@@ -88,7 +88,7 @@ pub(crate) struct WkbInfo {
 /// OGC WKB header.
 pub(crate) fn read_wkb_header<R: Read>(raw: &mut R) -> Result<WkbInfo> {
     let byte_order = raw.ioread::<u8>()?;
-    let endian = if byte_order == WKBByteOrder::XDR as u8 {
+    let endian = if byte_order == WKBByteOrder::Xdr as u8 {
         scroll::BE
     } else {
         scroll::LE
@@ -113,7 +113,7 @@ pub(crate) fn read_wkb_header<R: Read>(raw: &mut R) -> Result<WkbInfo> {
 /// EWKB header according to https://git.osgeo.org/gitea/postgis/postgis/src/branch/master/doc/ZMSgeoms.txt
 fn read_ewkb_header<R: Read>(raw: &mut R) -> Result<WkbInfo> {
     let byte_order = raw.ioread::<u8>()?;
-    let endian = if byte_order == WKBByteOrder::XDR as u8 {
+    let endian = if byte_order == WKBByteOrder::Xdr as u8 {
         scroll::BE
     } else {
         scroll::LE

--- a/geozero/src/wkb/wkb_writer.rs
+++ b/geozero/src/wkb/wkb_writer.rs
@@ -127,7 +127,7 @@ impl<'a, W: Write> WkbWriter<'a, W> {
         if self.empty {
             flags |= 0b0001_0000;
         }
-        let env_info: u8 = if self.envelope.len() == 0 {
+        let env_info: u8 = if self.envelope.is_empty() {
             0 // no envelope
         } else {
             match (self.envelope_dims.z, self.envelope_dims.m) {

--- a/geozero/src/wkb/wkb_writer.rs
+++ b/geozero/src/wkb/wkb_writer.rs
@@ -65,9 +65,9 @@ impl<'a, W: Write> WkbWriter<'a, W> {
     /// OGC WKB header
     fn write_wkb_header(&mut self, wkb_type: WKBGeometryType) -> Result<()> {
         let byte_order = if self.endian == scroll::BE {
-            WKBByteOrder::XDR
+            WKBByteOrder::Xdr
         } else {
-            WKBByteOrder::NDR
+            WKBByteOrder::Ndr
         };
         self.out.iowrite(byte_order as u8)?;
         let mut type_id = wkb_type as u32;
@@ -84,9 +84,9 @@ impl<'a, W: Write> WkbWriter<'a, W> {
     /// EWKB header according to https://git.osgeo.org/gitea/postgis/postgis/src/branch/master/doc/ZMSgeoms.txt
     fn write_ewkb_header(&mut self, wkb_type: WKBGeometryType) -> Result<()> {
         let byte_order = if self.endian == scroll::BE {
-            WKBByteOrder::XDR
+            WKBByteOrder::Xdr
         } else {
-            WKBByteOrder::NDR
+            WKBByteOrder::Ndr
         };
         self.out.iowrite(byte_order as u8)?;
 

--- a/geozero/src/wkt/wkt_reader.rs
+++ b/geozero/src/wkt/wkt_reader.rs
@@ -156,7 +156,7 @@ fn process_multilinestring<P: GeomProcessor>(
 ) -> Result<()> {
     processor.multilinestring_begin(multilinestring.0.len(), idx)?;
     for (idxc, linestring) in multilinestring.0.iter().enumerate() {
-        process_linestring(&linestring, false, idxc, processor)?
+        process_linestring(linestring, false, idxc, processor)?
     }
     processor.multilinestring_end(idx)
 }
@@ -181,7 +181,7 @@ fn process_multi_polygon<P: GeomProcessor>(
 ) -> Result<()> {
     processor.multipolygon_begin(multi_polygon.0.len(), idx)?;
     for (idxp, polygon) in multi_polygon.0.iter().enumerate() {
-        process_polygon(&polygon, false, idxp, processor)?;
+        process_polygon(polygon, false, idxp, processor)?;
     }
     processor.multipolygon_end(idx)
 }

--- a/geozero/src/wkt/wkt_writer.rs
+++ b/geozero/src/wkt/wkt_writer.rs
@@ -45,9 +45,9 @@ impl<W: Write> GeomProcessor for WktWriter<'_, W> {
     }
     fn xy(&mut self, x: f64, y: f64, idx: usize) -> Result<()> {
         if idx == 0 {
-            self.out.write_all(&format!("{} {}", x, y).as_bytes())?;
+            self.out.write_all(format!("{} {}", x, y).as_bytes())?;
         } else {
-            self.out.write_all(&format!(",{} {}", x, y).as_bytes())?;
+            self.out.write_all(format!(",{} {}", x, y).as_bytes())?;
         }
         Ok(())
     }
@@ -62,15 +62,15 @@ impl<W: Write> GeomProcessor for WktWriter<'_, W> {
         idx: usize,
     ) -> Result<()> {
         if idx == 0 {
-            self.out.write_all(&format!("{} {}", x, y).as_bytes())?;
+            self.out.write_all(format!("{} {}", x, y).as_bytes())?;
         } else {
-            self.out.write_all(&format!(",{} {}", x, y).as_bytes())?;
+            self.out.write_all(format!(",{} {}", x, y).as_bytes())?;
         }
         if let Some(z) = z {
-            self.out.write_all(&format!(" {}", z).as_bytes())?;
+            self.out.write_all(format!(" {}", z).as_bytes())?;
         }
         if let Some(m) = m {
-            self.out.write_all(&format!(" {}", m).as_bytes())?;
+            self.out.write_all(format!(" {}", m).as_bytes())?;
         }
         Ok(())
     }

--- a/geozero/tests/gdal.rs
+++ b/geozero/tests/gdal.rs
@@ -11,7 +11,7 @@ fn ogr_to_svg() -> Result<(), gdal::errors::GdalError> {
     let mut out: Vec<u8> = Vec::new();
     for feature in layer.features() {
         let geom = feature.geometry();
-        assert!(process_geom(&geom, &mut SvgWriter::new(&mut out, true)).is_ok());
+        assert!(process_geom(geom, &mut SvgWriter::new(&mut out, true)).is_ok());
     }
     assert_eq!(
         &std::str::from_utf8(&out).unwrap()[..53],

--- a/geozero/tests/polylabel.rs
+++ b/geozero/tests/polylabel.rs
@@ -14,8 +14,8 @@ fn country_labels() -> Result<()> {
     while let Some(feature) = fgb.next()? {
         let name: String = feature.property("name").unwrap();
         if let Ok(Geometry::MultiPolygon(mpoly)) = feature.to_geo() {
-            if let Some(poly) = &mpoly.0.iter().next() {
-                let label_pos = polylabel(&poly, &0.10).unwrap();
+            if let Some(poly) = &mpoly.0.first() {
+                let label_pos = polylabel(poly, &0.10).unwrap();
                 println!("{}: {:?}", name, label_pos);
                 if !vec!["Bermuda", "Falkland Islands"].contains(&name.as_str()) {
                     assert!(mpoly.contains(&label_pos));

--- a/geozero/tests/postgis.rs
+++ b/geozero/tests/postgis.rs
@@ -39,7 +39,7 @@ mod postgis_postgres {
                 vec![(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0), (0.0, 0.0)].into()
             );
         } else {
-            assert!(false, "Conversion to geo_types::Geometry failed");
+            panic!("Conversion to geo_types::Geometry failed");
         }
 
         let row = client.query_one("SELECT NULL::geometry", &[])?;
@@ -204,7 +204,7 @@ mod postgis_sqlx {
                 vec![(0.0, 0.0), (2.0, 0.0), (2.0, 2.0), (0.0, 2.0), (0.0, 0.0)].into()
             );
         } else {
-            assert!(false, "Conversion to geo_types::Geometry failed");
+            panic!("Conversion to geo_types::Geometry failed");
         }
 
         let row: (wkb::Decode<geo_types::Geometry<f64>>,) = sqlx::query_as("SELECT NULL::geometry")

--- a/geozero/tests/postgis.rs
+++ b/geozero/tests/postgis.rs
@@ -105,10 +105,7 @@ mod postgis_postgres {
             }
 
             fn accepts(ty: &Type) -> bool {
-                match ty.name() {
-                    "geography" | "geometry" => true,
-                    _ => false,
-                }
+                matches!(ty.name(), "geography" | "geometry")
             }
         }
 


### PR DESCRIPTION
This PR does a number of small changes to resolve clippy lints across the workspace. I'd recommend reviewing it commit-by-commit, since the overall diff is rather large.

A couple of notable things:

- This PR also enables Clippy to run in CI, to hopefully catch future regressions.
- I set up a clippy.toml for `geozero` to configure the "too-many-arguments" lint threshold to 8 (the default is 7) — this was done to avoid making breaking refactoring changes to the `GeomProcessor::coordinate` method. (I could just `#[allow(..)]` it instead if that makes more sense to reviewers.