### PR TITLE
Update dependencies, 2021 edition

### DIFF
--- a/geozero-bench/Cargo.toml
+++ b/geozero-bench/Cargo.toml
@@ -2,7 +2,7 @@
 name = "geozero-bench"
 version = "0.2.0"
 authors = ["Pirmin Kalberer <pka@sourcepole.ch>"]
-edition = "2018"
+edition = "2021"
 description = "GeoZero benchmark."
 homepage = "https://github.com/georust/geozero"
 repository = "https://github.com/georust/geozero"
@@ -16,13 +16,13 @@ geojson = "0.24.0"
 criterion = "0.4.0"
 geo-types = { version = "0.7", default-features = false }
 geo = "0.23" # { version = "0.17", features = ["postgis-integration"] }
-flatgeobuf = "3.24.0"
+flatgeobuf = "3.25.0"
 seek_bufread = "1.2"
 postgres = "0.19"
 postgis = "0.9.0"
 gdal = { version = "0.14", default-features = false }
 gdal-sys = { version = "0.8" }
-tokio = { version = "1.2.0", default-features = false, features = ["rt-multi-thread"] }
+tokio = { version = "1.27.0", default-features = false, features = ["rt-multi-thread"] }
 
 [[bench]]
 name = "geobench"

--- a/geozero-cli/Cargo.toml
+++ b/geozero-cli/Cargo.toml
@@ -2,7 +2,7 @@
 name = "geozero-cli"
 version = "0.1.0"
 authors = ["Pirmin Kalberer <pka@sourcepole.ch>"]
-edition = "2018"
+edition = "2021"
 default-run = "geozero"
 
 [[bin]]
@@ -11,8 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 geozero = { version = "0.9.4", features = ["with-csv"] }
-flatgeobuf = "3.24.0"
+flatgeobuf = "3.25.0"
 async-trait = "0.1"
 clap = { version = "3.1.18", features = ["derive"] }
-tokio = { version = "1.2.0", features = ["full"] }
+tokio = { version = "1.27.0", features = ["full"] }
 env_logger = "0.10.0"

--- a/geozero-shp/Cargo.toml
+++ b/geozero-shp/Cargo.toml
@@ -2,7 +2,7 @@
 name = "geozero-shp"
 version = "0.4.0"
 authors = ["Pirmin Kalberer <pka@sourcepole.ch>"]
-edition = "2018"
+edition = "2021"
 description = "Shapefile reader with GeoZero API."
 homepage = "https://github.com/georust/geozero"
 repository = "https://github.com/georust/geozero"

--- a/geozero/Cargo.toml
+++ b/geozero/Cargo.toml
@@ -2,8 +2,8 @@
 name = "geozero"
 version = "0.9.7"
 authors = ["Pirmin Kalberer <pka@sourcepole.ch>"]
-edition = "2018"
-description = "Zero-Copy reading and writing of geospatial data."
+edition = "2021"
+description = "Zero-Copy reading and writing of geospatial data in WKT/WKB, GeoJSON, MVT, GDAL, and other formats."
 homepage = "https://github.com/georust/geozero"
 repository = "https://github.com/georust/geozero"
 readme = "../README.md"
@@ -31,12 +31,12 @@ with-mvt = ["prost", "prost-build"]
 with-tessellator = ["lyon"]
 
 [dependencies]
-csv = { version = "1.1.6", optional = true }
+csv = { version = "1.2.1", optional = true }
 thiserror = "1.0"
 geojson = { version = "0.24.0", default-features = false, optional = true }
 serde_json = "1.0.79"
 geo-types = { version = "0.7", default-features = false, optional = true }
-geos = { version = "8.0", optional = true }
+geos = { version = "8.1", optional = true }
 gdal = { version = "0.14", default-features = false, optional = true }
 gdal-sys = { version = "0.8", optional = true }
 gpx = { version = "0.8", default-features = false, optional = true }
@@ -47,10 +47,10 @@ sqlx = { version = "0.6", default-features = false, optional = true }
 diesel = { version = "2.0.2", default-features = false, optional = true }
 byteorder = { version = "1.4.3", default-features = false, optional = true }
 postgres-types = { version = "0.2", optional = true }
-bytes = { version = "1.0", optional = true }
+bytes = { version = "1.4", optional = true }
 prost = { version = "0.11.0", optional = true }
 wkt = { version = "0.10.0", optional = true }
-arrow2 = { version = "0.14", optional = true, features = ["io_ipc"]}
+arrow2 = { version = "0.17", optional = true, features = ["io_ipc"]}
 
 [dev-dependencies]
 seek_bufread = "1.2"
@@ -59,12 +59,12 @@ geo = "0.23"
 wkt = "0.10.0"
 kdbush = "0.2"
 polylabel = "2.4"
-flatgeobuf = "3.24.0"
+flatgeobuf = "3.25.0"
 #flatgeobuf = { git = "https://github.com/pka/flatgeobuf", branch="geozero-0.9" }
 postgres = "0.19"
 sqlx = { version = "0.6", default-features = false, features = [ "runtime-tokio-native-tls", "macros", "time", "postgres", "sqlite" ] }
 diesel = { version = "2.0.2", default-features = false, features = [ "postgres" ] }
-tokio = { version = "1.17.0", default-features = false, features = ["macros"] }
+tokio = { version = "1.27.0", default-features = false, features = ["macros"] }
 
 [build-dependencies]
 prost-build = { version = "0.11", optional = true }

--- a/geozero/src/arrow/geoarrow_reader.rs
+++ b/geozero/src/arrow/geoarrow_reader.rs
@@ -1,7 +1,8 @@
 use crate::error::Result;
 use crate::wkb::wkb_reader::{process_wkb_geom_n, read_wkb_header};
 use crate::{GeomProcessor, GeozeroGeometry};
-use arrow2::array::{BinaryArray, Offset};
+use arrow2::array::BinaryArray;
+use arrow2::types::Offset;
 
 impl GeozeroGeometry for BinaryArray<i32> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> Result<()> {


### PR DESCRIPTION
Bumped some versions to the more up-to-date ones, and fixed arrow2 array offset usage.
Updating `clap 3->4` will be a separate PR.  Updating `geo` to 0.24 has some compilation issues - not sure how to fix those yet.