### PR TITLE
Clippy and minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Supported dimensions: X, Y, Z, M, T
 ## Conversion API
 
 Convert a GeoJSON polygon to geo-types and calculate centroid:
-```rust
+```rust,ignore
 let geojson = GeoJson(r#"{"type": "Polygon", "coordinates": [[[0, 0], [10, 0], [10, 6], [0, 6], [0, 0]]]}"#);
 if let Ok(Geometry::Polygon(poly)) = geojson.to_geo() {
     assert_eq!(poly.centroid().unwrap(), Point::new(5.0, 3.0));
@@ -64,7 +64,7 @@ Full source code: [geo_types.rs](./geozero/tests/geo_types.rs)
 
 
 Convert GeoJSON to a [GEOS](https://github.com/georust/geos) prepared geometry:
-```rust
+```rust,ignore
 let geojson = GeoJson(r#"{"type": "Polygon", "coordinates": [[[0, 0], [10, 0], [10, 6], [0, 6], [0, 0]]]}"#);
 let geom = geojson.to_geos().expect("GEOS conversion failed");
 let prepared_geom = geom.to_prepared_geom().expect("to_prepared_geom failed");
@@ -75,7 +75,7 @@ Full source code: [geos.rs](./geozero/tests/geos.rs)
 
 
 Read FlatGeobuf subset as GeoJSON:
-```rust
+```rust,ignore
 let mut file = BufReader::new(File::open("countries.fgb")?);
 let mut fgb = FgbReader::open(&mut file)?.select_bbox(8.8, 47.2, 9.5, 55.3)?;
 println!("{}", fgb.to_json()?);
@@ -84,7 +84,7 @@ Full source code: [geojson.rs](./geozero/tests/geojson.rs)
 
 
 Read FlatGeobuf data as geo-types geometries and calculate label position with [polylabel-rs](https://github.com/urschrei/polylabel-rs):
-```rust
+```rust,ignore
 let mut file = BufReader::new(File::open("countries.fgb")?);
 let mut fgb = FgbReader::open(&mut file)?.select_all()?;
 while let Some(feature) = fgb.next()? {
@@ -103,7 +103,7 @@ Full source code: [polylabel.rs](./geozero/tests/polylabel.rs)
 ## PostGIS usage examples
 
 Select and insert geo-types geometries with rust-postgres:
-```rust
+```rust,ignore
 let mut client = Client::connect(&std::env::var("DATABASE_URL").unwrap(), NoTls)?;
 
 let row = client.query_one(
@@ -128,7 +128,7 @@ let _ = client.execute(
 ```
 
 Select and insert geo-types geometries with SQLx:
-```rust
+```rust,ignore
 let pool = PgPoolOptions::new()
     .max_connections(5)
     .connect(&env::var("DATABASE_URL").unwrap())
@@ -157,7 +157,7 @@ let _ = sqlx::query(
 ```
 
 Using compile-time verification requires [type overrides](https://docs.rs/sqlx/latest/sqlx/macro.query.html#force-a-differentcustom-type): 
-```rust
+```rust,ignore
 let _ = sqlx::query!(
     "INSERT INTO point2d (datetimefield, geom) VALUES(now(), $1::geometry)",
     wkb::Encode(geom) as _
@@ -187,7 +187,7 @@ Full source code: [postgis.rs](./geozero/tests/postgis.rs)
 ## Processing API
 
 Count vertices of an input geometry:
-```rust
+```rust,ignore
 struct VertexCounter(u64);
 
 impl GeomProcessor for VertexCounter {
@@ -203,7 +203,7 @@ geometry.process(&mut vertex_counter, GeometryType::MultiPolygon)?;
 Full source code: [geozero-api.rs](./geozero/tests/geozero-api.rs)
 
 Find maximal height in 3D polygons:
-```rust
+```rust,ignore
 struct MaxHeightFinder(f64);
 
 impl GeomProcessor for MaxHeightFinder {
@@ -226,7 +226,7 @@ while let Some(feature) = fgb.next()? {
 Full source code: [geozero-api.rs](./geozero/tests/geozero-api.rs)
 
 Render polygons:
-```rust
+```rust,ignore
 struct PathDrawer<'a> {
     canvas: &'a mut CanvasRenderingContext2D,
     path: Path2D,
@@ -254,7 +254,7 @@ impl<'a> GeomProcessor for PathDrawer<'a> {
 Full source code: [flatgeobuf-gpu](https://github.com/pka/flatgeobuf-gpu)
 
 Read a FlatGeobuf dataset with async HTTP client applying a bbox filter and convert to GeoJSON:
-```rust
+```rust,ignore
 let url = "https://flatgeobuf.org/test/data/countries.fgb";
 let mut fgb = HttpFgbReader::open(url)
     .await?
@@ -269,7 +269,7 @@ Full source code: [geojson.rs](./geozero/tests/geojson.rs)
 
 
 Create a KD-tree index with [kdbush](https://github.com/pka/rust-kdbush):
-```rust
+```rust,ignore
 struct PointIndex {
     pos: usize,
     index: KDBush,

--- a/geozero-shp/tests/reader.rs
+++ b/geozero-shp/tests/reader.rs
@@ -99,7 +99,7 @@ fn property_filter() -> Result<(), geozero_shp::Error> {
         .count();
     assert_eq!(cnt, 5);
     // Filter does not work as expected. *All* features are written and converted into GeoJSON!
-    assert!(&from_utf8(&json).unwrap().contains("\"AREA\": 5268.813"));
+    assert!(from_utf8(&json).unwrap().contains(r#""AREA": 5268.813"#));
     Ok(())
 }
 

--- a/geozero/src/api.rs
+++ b/geozero/src/api.rs
@@ -83,7 +83,7 @@ pub trait FeatureProperties {
         self.process_properties(&mut reader)?;
         reader.value
     }
-    /// Return all properties in a HashMap
+    /// Return all properties in a `HashMap`
     ///
     /// Use `process_properties` for zero-copy access
     fn properties(&self) -> Result<HashMap<String, String>> {

--- a/geozero/src/csv/csv_reader.rs
+++ b/geozero/src/csv/csv_reader.rs
@@ -2,6 +2,7 @@ use crate::error::{GeozeroError, Result};
 use crate::{ColumnValue, FeatureProcessor, GeomProcessor, GeozeroDatasource, GeozeroGeometry};
 
 use std::io::Read;
+use std::str::FromStr;
 
 pub struct Csv<'a> {
     csv_text: &'a str,
@@ -121,7 +122,6 @@ pub fn process_csv_geom(
         let geometry_field = record
             .get(geometry_idx)
             .ok_or(GeozeroError::ColumnNotFound)?;
-        use std::str::FromStr;
         let wkt = wkt::Wkt::from_str(geometry_field)
             .map_err(|e| GeozeroError::Geometry(e.to_string()))?;
         crate::wkt::wkt_reader::process_wkt_geom_n(&wkt.item, record_idx, processor).map_err(
@@ -272,7 +272,7 @@ mod tests {
         let actual_geojson = csv.to_json().unwrap();
         let actual_geojson: serde_json::Value = serde_json::from_str(&actual_geojson).unwrap();
 
-        assert_eq!(expected_geojson, actual_geojson,)
+        assert_eq!(expected_geojson, actual_geojson)
     }
     #[test]
     fn csv_string_feature_processor() {
@@ -320,7 +320,7 @@ mod tests {
         let actual_geojson = csv.to_json().unwrap();
         let actual_geojson: serde_json::Value = serde_json::from_str(&actual_geojson).unwrap();
 
-        assert_eq!(expected_geojson, actual_geojson,)
+        assert_eq!(expected_geojson, actual_geojson)
     }
 
     #[test]
@@ -369,7 +369,7 @@ mod tests {
         let actual_geojson = csv.to_json().unwrap();
         let actual_geojson: serde_json::Value = serde_json::from_str(&actual_geojson).unwrap();
 
-        assert_eq!(expected_geojson, actual_geojson,)
+        assert_eq!(expected_geojson, actual_geojson)
     }
 
     #[test]

--- a/geozero/src/csv/csv_writer.rs
+++ b/geozero/src/csv/csv_writer.rs
@@ -261,7 +261,7 @@ mod buffering_wkt_writer {
         }
 
         pub(crate) fn clear(&mut self) {
-            self.buffer.clear()
+            self.buffer.clear();
         }
 
         pub(crate) fn bytes(&self) -> &[u8] {

--- a/geozero/src/csv/mod.rs
+++ b/geozero/src/csv/mod.rs
@@ -6,7 +6,7 @@ pub use csv_reader::*;
 pub use csv_writer::*;
 
 pub(crate) mod conversion {
-    use super::csv_writer::*;
+    use crate::csv::CsvWriter;
     use crate::error::Result;
     use crate::GeozeroDatasource;
 

--- a/geozero/src/gdal/gdal_writer.rs
+++ b/geozero/src/gdal/gdal_writer.rs
@@ -13,7 +13,7 @@ pub struct GdalWriter {
 
 impl GdalWriter {
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
     pub fn geometry(&self) -> &Geometry {
         &self.geom

--- a/geozero/src/gdal/mod.rs
+++ b/geozero/src/gdal/mod.rs
@@ -6,8 +6,8 @@ pub use gdal_reader::*;
 pub use gdal_writer::*;
 
 pub(crate) mod conversion {
-    use super::gdal_writer::*;
     use crate::error::Result;
+    use crate::gdal::GdalWriter;
     use crate::{CoordDimensions, GeozeroGeometry};
     use gdal::vector::Geometry;
 
@@ -34,8 +34,8 @@ pub(crate) mod conversion {
 
 #[cfg(feature = "with-wkb")]
 mod wkb {
-    use super::gdal_writer::*;
     use crate::error::Result;
+    use crate::gdal::GdalWriter;
     use crate::wkb::{FromWkb, WkbDialect};
     use std::io::Read;
 

--- a/geozero/src/geo_types/geo_types_reader.rs
+++ b/geozero/src/geo_types/geo_types_reader.rs
@@ -1,6 +1,6 @@
 use crate::error::Result;
 use crate::{GeomProcessor, GeozeroGeometry};
-use geo_types::*;
+use geo_types::{Coord, Geometry, LineString, Polygon};
 
 impl GeozeroGeometry for geo_types::Geometry<f64> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> Result<()> {

--- a/geozero/src/geo_types/geo_types_writer.rs
+++ b/geozero/src/geo_types/geo_types_writer.rs
@@ -1,25 +1,28 @@
 use crate::error::{GeozeroError, Result};
 use crate::{FeatureProcessor, GeomProcessor, PropertyProcessor};
-use geo_types::*;
+use geo_types::{
+    coord, Coord, Geometry, GeometryCollection, LineString, MultiLineString, MultiPoint,
+    MultiPolygon, Point, Polygon,
+};
 use std::mem;
 
 /// Generator for geo-types geometry type.
 #[derive(Default)]
 pub struct GeoWriter {
     geoms: Vec<Geometry<f64>>,
-    // Stack of any in-progress (potentially nested) GeometryCollections
+    /// Stack of any in-progress (potentially nested) GeometryCollections
     collections: Vec<Vec<Geometry<f64>>>,
-    // In-progress multi-polygon
+    /// In-progress multi-polygon
     polygons: Option<Vec<Polygon<f64>>>,
-    // In-progress polygon or multi_linestring
+    /// In-progress polygon or multi_linestring
     line_strings: Option<Vec<LineString<f64>>>,
-    // In-progress point or line_string
+    /// In-progress point or line_string
     coords: Option<Vec<Coord<f64>>>,
 }
 
 impl GeoWriter {
     pub fn new() -> GeoWriter {
-        Default::default()
+        Self::default()
     }
 
     pub fn take_geometry(&mut self) -> Option<Geometry<f64>> {
@@ -27,7 +30,7 @@ impl GeoWriter {
             0 => None,
             1 => Some(self.geoms.pop().unwrap()),
             _ => {
-                let geoms = std::mem::take(&mut self.geoms);
+                let geoms = mem::take(&mut self.geoms);
                 Some(Geometry::GeometryCollection(GeometryCollection(geoms)))
             }
         }

--- a/geozero/src/geo_types/mod.rs
+++ b/geozero/src/geo_types/mod.rs
@@ -6,8 +6,8 @@ pub use geo_types_reader::*;
 pub use geo_types_writer::*;
 
 pub(crate) mod conversion {
-    use super::geo_types_writer::*;
     use crate::error::{GeozeroError, Result};
+    use crate::geo_types::GeoWriter;
     use crate::GeozeroGeometry;
 
     /// Convert to geo-types Geometry.
@@ -28,8 +28,8 @@ pub(crate) mod conversion {
 
 #[cfg(feature = "with-wkb")]
 mod wkb {
-    use super::geo_types_writer::*;
     use crate::error::{GeozeroError, Result};
+    use crate::geo_types::GeoWriter;
     use crate::wkb::{FromWkb, WkbDialect};
     use std::io::Read;
 

--- a/geozero/src/geojson/geojson_reader.rs
+++ b/geozero/src/geojson/geojson_reader.rs
@@ -262,7 +262,7 @@ fn process_multi_point<P: GeomProcessor>(
     processor.multipoint_begin(multi_point_type.len(), idx)?;
     let multi_dim = processor.multi_dim();
     for (idxc, point_type) in multi_point_type.iter().enumerate() {
-        process_coord(point_type, multi_dim, idxc, processor)?
+        process_coord(point_type, multi_dim, idxc, processor)?;
     }
     processor.multipoint_end(idx)
 }
@@ -276,7 +276,7 @@ fn process_linestring<P: GeomProcessor>(
     processor.linestring_begin(tagged, linestring_type.len(), idx)?;
     let multi_dim = processor.multi_dim();
     for (idxc, point_type) in linestring_type.iter().enumerate() {
-        process_coord(point_type, multi_dim, idxc, processor)?
+        process_coord(point_type, multi_dim, idxc, processor)?;
     }
     processor.linestring_end(tagged, idx)
 }
@@ -288,7 +288,7 @@ fn process_multilinestring<P: GeomProcessor>(
 ) -> Result<()> {
     processor.multilinestring_begin(multilinestring_type.len(), idx)?;
     for (idxc, linestring_type) in multilinestring_type.iter().enumerate() {
-        process_linestring(linestring_type, false, idxc, processor)?
+        process_linestring(linestring_type, false, idxc, processor)?;
     }
     processor.multilinestring_end(idx)
 }
@@ -301,7 +301,7 @@ fn process_polygon<P: GeomProcessor>(
 ) -> Result<()> {
     processor.polygon_begin(tagged, polygon_type.len(), idx)?;
     for (idxl, linestring_type) in polygon_type.iter().enumerate() {
-        process_linestring(linestring_type, false, idxl, processor)?
+        process_linestring(linestring_type, false, idxl, processor)?;
     }
     processor.polygon_end(tagged, idx)
 }

--- a/geozero/src/geojson/geojson_writer.rs
+++ b/geozero/src/geojson/geojson_writer.rs
@@ -220,9 +220,10 @@ impl<W: Write> PropertyProcessor for GeoJsonWriter<'_, W> {
             ColumnValue::ULong(v) => write_num_prop(self.out, colname, &v)?,
             ColumnValue::Float(v) => write_num_prop(self.out, colname, &v)?,
             ColumnValue::Double(v) => write_num_prop(self.out, colname, &v)?,
-            ColumnValue::String(v) => write_str_prop(self.out, colname, v)?,
+            ColumnValue::String(v) | ColumnValue::DateTime(v) => {
+                write_str_prop(self.out, colname, v)?;
+            }
             ColumnValue::Json(_v) => (),
-            ColumnValue::DateTime(v) => write_str_prop(self.out, colname, v)?,
             ColumnValue::Binary(_v) => (),
         };
         Ok(false)

--- a/geozero/src/geojson/mod.rs
+++ b/geozero/src/geojson/mod.rs
@@ -6,8 +6,8 @@ pub use geojson_reader::*;
 pub use geojson_writer::*;
 
 pub(crate) mod conversion {
-    use super::geojson_writer::*;
     use crate::error::Result;
+    use crate::geojson::GeoJsonWriter;
     use crate::{GeozeroDatasource, GeozeroGeometry};
 
     /// Convert to GeoJSON.
@@ -56,9 +56,8 @@ impl From<geojson::Error> for crate::error::GeozeroError {
 
 #[cfg(feature = "with-wkb")]
 mod wkb {
-    use super::geojson_writer::*;
     use crate::error::Result;
-    use crate::geojson::GeoJsonString;
+    use crate::geojson::{GeoJsonString, GeoJsonWriter};
     use crate::wkb::{FromWkb, WkbDialect};
     use std::io::Read;
 

--- a/geozero/src/geometry_processor.rs
+++ b/geozero/src/geometry_processor.rs
@@ -133,35 +133,35 @@ pub trait GeomProcessor {
         Ok(())
     }
 
-    /// Begin of LineString processing
+    /// Begin of `LineString` processing
     ///
-    /// An untagged LineString is either a Polygon ring or part of a MultiLineString
+    /// An untagged `LineString` is either a Polygon ring or part of a `MultiLineString`
     ///
     /// Next: size * xy/coordinate
     fn linestring_begin(&mut self, tagged: bool, size: usize, idx: usize) -> Result<()> {
         Ok(())
     }
 
-    /// End of LineString processing
+    /// End of `LineString` processing
     fn linestring_end(&mut self, tagged: bool, idx: usize) -> Result<()> {
         Ok(())
     }
 
-    /// Begin of MultiLineString processing
+    /// Begin of `MultiLineString` processing
     ///
     /// Next: size * LineString (untagged)
     fn multilinestring_begin(&mut self, size: usize, idx: usize) -> Result<()> {
         Ok(())
     }
 
-    /// End of MultiLineString processing
+    /// End of `MultiLineString` processing
     fn multilinestring_end(&mut self, idx: usize) -> Result<()> {
         Ok(())
     }
 
     /// Begin of Polygon processing
     ///
-    /// An untagged Polygon is part of a MultiPolygon
+    /// An untagged Polygon is part of a `MultiPolygon`
     ///
     /// Next: size * LineString (untagged) = rings
     fn polygon_begin(&mut self, tagged: bool, size: usize, idx: usize) -> Result<()> {
@@ -173,31 +173,36 @@ pub trait GeomProcessor {
         Ok(())
     }
 
-    /// Begin of MultiPolygon processing
+    /// Begin of `MultiPolygon` processing
     ///
     /// Next: size * Polygon (untagged)
     fn multipolygon_begin(&mut self, size: usize, idx: usize) -> Result<()> {
         Ok(())
     }
 
-    /// End of MultiPolygon processing
+    /// End of `MultiPolygon` processing
     fn multipolygon_end(&mut self, idx: usize) -> Result<()> {
         Ok(())
     }
 
-    /// Begin of GeometryCollection processing
+    /// Begin of `GeometryCollection` processing
     fn geometrycollection_begin(&mut self, size: usize, idx: usize) -> Result<()> {
         Ok(())
     }
 
-    /// End of GeometryCollection processing
+    /// End of `GeometryCollection` processing
     fn geometrycollection_end(&mut self, idx: usize) -> Result<()> {
         Ok(())
     }
 
-    /// Begin of CircularString processing
+    /// Begin of `CircularString` processing
     ///
-    /// The CircularString is the basic curve type, similar to a LineString in the linear world. A single segment required three points, the start and end points (first and third) and any other point on the arc. The exception to this is for a closed circle, where the start and end points are the same. In this case the second point MUST be the center of the arc, ie the opposite side of the circle. To chain arcs together, the last point of the previous arc becomes the first point of the next arc, just like in LineString. This means that a valid circular string must have an odd number of points greated than 1.
+    /// The `CircularString` is the basic curve type, similar to a `LineString` in the linear world.
+    /// A single segment required three points, the start and end points (first and third) and any other point on the arc.
+    /// The exception to this is for a closed circle, where the start and end points are the same.
+    /// In this case the second point MUST be the center of the arc, ie the opposite side of the circle.
+    /// To chain arcs together, the last point of the previous arc becomes the first point of the next arc,
+    /// just like in LineString. This means that a valid circular string must have an odd number of points greater than 1.
     ///
     /// Next: size * xy/coordinate
     fn circularstring_begin(&mut self, size: usize, idx: usize) -> Result<()> {

--- a/geozero/src/geos/geos_reader.rs
+++ b/geozero/src/geos/geos_reader.rs
@@ -20,13 +20,13 @@ impl GeozeroGeometry for geos::Geometry<'_> {
 impl From<geos::Error> for GeozeroError {
     fn from(error: geos::Error) -> Self {
         match error {
-            geos::Error::InvalidGeometry(e) => GeozeroError::Geometry(e),
-            geos::Error::ImpossibleOperation(e) => GeozeroError::Geometry(e),
-            geos::Error::GeosError(e) => GeozeroError::Geometry(e),
+            geos::Error::InvalidGeometry(e)
+            | geos::Error::ImpossibleOperation(e)
+            | geos::Error::GeosError(e)
+            | geos::Error::NoConstructionFromNullPtr(e)
+            | geos::Error::ConversionError(e)
+            | geos::Error::GenericError(e) => GeozeroError::Geometry(e),
             geos::Error::GeosFunctionError(_, _) => GeozeroError::GeometryFormat,
-            geos::Error::NoConstructionFromNullPtr(e) => GeozeroError::Geometry(e),
-            geos::Error::ConversionError(e) => GeozeroError::Geometry(e),
-            geos::Error::GenericError(e) => GeozeroError::Geometry(e),
         }
     }
 }

--- a/geozero/src/geos/geos_writer.rs
+++ b/geozero/src/geos/geos_writer.rs
@@ -13,7 +13,7 @@ pub struct GeosWriter<'a> {
 
 impl<'a> GeosWriter<'a> {
     pub fn new() -> Self {
-        Default::default()
+        Self::default()
     }
     fn add_coord_seq(&mut self, len: usize) -> Result<()> {
         self.cs
@@ -132,7 +132,7 @@ impl GeomProcessor for GeosWriter<'_> {
         if tagged {
             self.geom = gpoly;
         } else {
-            self.polys.push(gpoly)
+            self.polys.push(gpoly);
         }
         Ok(())
     }

--- a/geozero/src/geos/mod.rs
+++ b/geozero/src/geos/mod.rs
@@ -6,8 +6,8 @@ pub use geos_reader::*;
 pub use geos_writer::*;
 
 pub(crate) mod conversion {
-    use super::geos_writer::*;
     use crate::error::Result;
+    use crate::geos::GeosWriter;
     use crate::GeozeroGeometry;
 
     /// Convert to GEOS geometry.
@@ -27,8 +27,8 @@ pub(crate) mod conversion {
 
 #[cfg(feature = "with-wkb")]
 mod wkb {
-    use super::geos_writer::*;
     use crate::error::Result;
+    use crate::geos::GeosWriter;
     use crate::wkb::{FromWkb, WkbDialect};
     use std::io::Read;
 

--- a/geozero/src/gpx/gpx_reader.rs
+++ b/geozero/src/gpx/gpx_reader.rs
@@ -58,10 +58,7 @@ fn process_top_level_tracks<P: crate::GeomProcessor>(
     processor: &mut P,
     index: &mut usize,
 ) -> crate::error::Result<()> {
-    if gpx_reader.tracks.is_empty() {
-        return Ok(());
-    }
-    for track in gpx_reader.tracks.iter() {
+    for track in &gpx_reader.tracks {
         process_track_segments(track, processor, *index)?;
         *index += 1;
     }

--- a/geozero/src/lib.rs
+++ b/geozero/src/lib.rs
@@ -1,6 +1,6 @@
 //! Zero-Copy reading and writing of geospatial data.
 //!
-//! GeoZero defines an API for reading geospatial data formats without an intermediate representation.
+//! `GeoZero` defines an API for reading geospatial data formats without an intermediate representation.
 //! It defines traits which can be implemented to read and convert to an arbitrary format
 //! or render geometries directly.
 //!
@@ -17,7 +17,7 @@
 //!
 //! ## Format conversion overview
 //!
-//! |           |                          [GeozeroGeometry]                           | Dimensions |                         [GeozeroDatasource]                          | Geometry Conversion |             [GeomProcessor]             |
+//! |           |                         [`GeozeroGeometry`]                          | Dimensions |                        [`GeozeroDatasource`]                         | Geometry Conversion |            [`GeomProcessor`]            |
 //! |-----------|----------------------------------------------------------------------|------------|----------------------------------------------------------------------|---------------------|-----------------------------------------|
 //! | CSV       | [csv::Csv], [csv::CsvString]                                         | XY         | -                                                                    | [ProcessToCsv]      | [CsvWriter](csv::CsvWriter)             |
 //! | geo-types | `geo_types::Geometry<f64>`                                           | XY         | -                                                                    | [ToGeo]             | [GeoWriter](geo_types::GeoWriter)       |
@@ -30,6 +30,21 @@
 //! | SVG       | -                                                                    | XY         | -                                                                    | [ToSvg]             | [SvgWriter](svg::SvgWriter)             |
 //! | WKB       | [Wkb](wkb::Wkb), [Ewkb](wkb::Ewkb), [GpkgWkb](wkb::GpkgWkb)          | XYZM       | -                                                                    | [ToWkb]             | [WkbWriter](wkb::WkbWriter)             |
 //! | WKT       | [wkt::WktStr], [wkt::WktString]                                      | XYZM       | [wkt::WktReader], [wkt::WktStr], [wkt::WktString]                    | [ToWkt]             | [WktWriter](wkt::WktWriter)             |
+
+#![allow(
+    clippy::many_single_char_names,
+    clippy::similar_names,
+    clippy::doc_markdown,
+    clippy::missing_errors_doc,
+    clippy::struct_excessive_bools,
+    clippy::must_use_candidate,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::redundant_closure_for_method_calls,
+    clippy::missing_panics_doc,
+    clippy::module_name_repetitions
+)]
 
 mod api;
 pub mod error;
@@ -114,7 +129,7 @@ pub struct ProcessorSink;
 
 impl ProcessorSink {
     pub fn new() -> ProcessorSink {
-        Default::default()
+        Self::default()
     }
 }
 

--- a/geozero/src/mvt/mod.rs
+++ b/geozero/src/mvt/mod.rs
@@ -11,9 +11,9 @@ pub use prost::Message;
 pub use vector_tile::*;
 
 pub(crate) mod conversion {
-    use super::mvt_writer::*;
     use crate::error::Result;
     use crate::mvt::vector_tile::tile;
+    use crate::mvt::MvtWriter;
     use crate::GeozeroGeometry;
 
     /// Convert to MVT geometry.
@@ -33,9 +33,9 @@ pub(crate) mod conversion {
 
 #[cfg(feature = "with-wkb")]
 mod wkb {
-    use super::mvt_writer::*;
     use crate::error::Result;
     use crate::mvt::vector_tile::tile;
+    use crate::mvt::MvtWriter;
     use crate::wkb::{FromWkb, WkbDialect};
     use std::io::Read;
 

--- a/geozero/src/mvt/mvt_commands.rs
+++ b/geozero/src/mvt/mvt_commands.rs
@@ -44,7 +44,7 @@ impl ParameterInteger {
 }
 
 #[test]
-fn test_paremeters() {
+fn test_parameters() {
     assert_eq!(ParameterInteger(50).value(), 25);
     assert_eq!(ParameterInteger::from(25), 50);
 }

--- a/geozero/src/mvt/mvt_writer.rs
+++ b/geozero/src/mvt/mvt_writer.rs
@@ -2,7 +2,7 @@
 //! <https://github.com/mapbox/vector-tile-spec/tree/master/2.1>
 
 use crate::error::{GeozeroError, Result};
-use crate::mvt::mvt_commands::*;
+use crate::mvt::mvt_commands::{Command, CommandInteger, ParameterInteger};
 use crate::mvt::vector_tile::{tile, tile::GeomType};
 use crate::GeomProcessor;
 
@@ -18,18 +18,20 @@ pub struct MvtWriter {
 #[derive(PartialEq)]
 enum LineState {
     None,
-    // Issue LineTo command afer first point
+    // Issue LineTo command after first point
     Line(usize),
     Ring(usize),
 }
 
 impl MvtWriter {
     pub fn new() -> MvtWriter {
-        Default::default()
+        Self::default()
     }
+
     pub fn geometry(&self) -> &tile::Feature {
         &self.feature
     }
+
     fn reserve(&mut self, capacity: usize) {
         let total = self.feature.geometry.len() + capacity;
         if total > self.feature.geometry.capacity() {
@@ -359,20 +361,20 @@ mod test_mvt {
         key: String,
         mvt_value: tile::Value,
     ) {
-        let keyentry = mvt_layer.keys.iter().position(|k| *k == key);
+        let key_entry = mvt_layer.keys.iter().position(|k| *k == key);
         // Optimization: maintain a hash table with key/index pairs
-        let keyidx = match keyentry {
+        let key_idx = match key_entry {
             None => {
                 mvt_layer.keys.push(key);
                 mvt_layer.keys.len() - 1
             }
             Some(idx) => idx,
         };
-        mvt_feature.tags.push(keyidx as u32);
+        mvt_feature.tags.push(key_idx as u32);
 
-        let valentry = mvt_layer.values.iter().position(|v| *v == mvt_value);
+        let val_entry = mvt_layer.values.iter().position(|v| *v == mvt_value);
         // Optimization: maintain a hash table with value/index pairs
-        let validx = match valentry {
+        let validx = match val_entry {
             None => {
                 mvt_layer.values.push(mvt_value);
                 mvt_layer.values.len() - 1

--- a/geozero/src/postgis/mod.rs
+++ b/geozero/src/postgis/mod.rs
@@ -48,6 +48,7 @@ mod postgis_sqlx;
 pub mod postgres {
     pub use super::postgis_postgres::*;
 }
+
 /// PostGIS geometry type encoding/decoding for SQLx.
 ///
 /// # PostGIS usage example with SQLx

--- a/geozero/src/postgis/postgis_diesel.rs
+++ b/geozero/src/postgis/postgis_diesel.rs
@@ -1,4 +1,4 @@
-use crate::postgis::postgis_diesel::sql_types::*;
+use crate::postgis::postgis_diesel::sql_types::{Geography, Geometry};
 use crate::wkb::Ewkb;
 
 use byteorder::WriteBytesExt;

--- a/geozero/src/property_processor.rs
+++ b/geozero/src/property_processor.rs
@@ -1,6 +1,7 @@
 use crate::error::{GeozeroError, Result};
 use std::collections::HashMap;
 use std::fmt;
+use std::hash::BuildHasher;
 
 /// Feature property value.
 #[derive(PartialEq, Debug)]
@@ -154,7 +155,7 @@ impl PropertyReadType for String {
     }
 }
 
-impl PropertyProcessor for HashMap<String, String> {
+impl<S: BuildHasher> PropertyProcessor for HashMap<String, String, S> {
     fn property(&mut self, _idx: usize, colname: &str, colval: &ColumnValue) -> Result<bool> {
         self.insert(colname.to_string(), colval.to_string());
         Ok(false)
@@ -175,6 +176,6 @@ fn convert_column_value() {
     assert_eq!(Result::<String>::from(v).unwrap(), "Yes".to_string());
     assert_eq!(
         Result::<i32>::from(v).unwrap_err().to_string(),
-        "expected a `ColumnValue::Int` value but found `String(\"Yes\")`"
+        r#"expected a `ColumnValue::Int` value but found `String("Yes")`"#
     );
 }

--- a/geozero/src/svg/mod.rs
+++ b/geozero/src/svg/mod.rs
@@ -6,8 +6,8 @@ pub use writer::SvgWriter;
 pub struct SvgString(pub String);
 
 pub(crate) mod conversion {
-    use super::*;
     use crate::error::Result;
+    use crate::svg::SvgWriter;
     use crate::FeatureProcessor;
     use crate::{GeozeroDatasource, GeozeroGeometry};
 
@@ -82,8 +82,8 @@ pub(crate) mod conversion {
 
 #[cfg(feature = "with-wkb")]
 mod wkb {
-    use super::*;
     use crate::error::Result;
+    use crate::svg::{SvgString, SvgWriter};
     use crate::wkb::{FromWkb, WkbDialect};
     use std::io::Read;
 

--- a/geozero/src/wkb/mod.rs
+++ b/geozero/src/wkb/mod.rs
@@ -19,9 +19,8 @@ pub use wkb_reader::*;
 pub use wkb_writer::*;
 
 pub(crate) mod conversion {
-    use super::wkb_writer::*;
     use crate::error::Result;
-    use crate::wkb::WkbDialect;
+    use crate::wkb::{WkbDialect, WkbWriter};
     use crate::{CoordDimensions, GeozeroGeometry};
 
     /// Convert to WKB.

--- a/geozero/src/wkb/wkb_writer.rs
+++ b/geozero/src/wkb/wkb_writer.rs
@@ -92,13 +92,13 @@ impl<'a, W: Write> WkbWriter<'a, W> {
 
         let mut type_id = wkb_type as u32;
         if self.dims.z {
-            type_id |= 0x80000000;
+            type_id |= 0x8000_0000;
         }
         if self.dims.m {
-            type_id |= 0x40000000;
+            type_id |= 0x4000_0000;
         }
         if self.srid.is_some() && self.first_header {
-            type_id |= 0x20000000;
+            type_id |= 0x2000_0000;
         }
         self.out.iowrite_with(type_id, self.endian)?;
 

--- a/geozero/src/wkt/mod.rs
+++ b/geozero/src/wkt/mod.rs
@@ -8,8 +8,8 @@ pub use wkt_reader::*;
 pub use wkt_writer::*;
 
 pub(crate) mod conversion {
-    use super::wkt_writer::*;
     use crate::error::Result;
+    use crate::wkt::WktWriter;
     use crate::{CoordDimensions, GeozeroGeometry};
 
     /// Convert to WKT.
@@ -38,10 +38,9 @@ pub(crate) mod conversion {
 
 #[cfg(feature = "with-wkb")]
 mod wkb {
-    use super::wkt_reader::*;
-    use super::wkt_writer::*;
     use crate::error::Result;
     use crate::wkb::{FromWkb, WkbDialect};
+    use crate::wkt::{WktString, WktWriter};
     use std::io::Read;
 
     impl FromWkb for WktString {

--- a/geozero/src/wkt/wkt_reader.rs
+++ b/geozero/src/wkt/wkt_reader.rs
@@ -144,7 +144,7 @@ fn process_linestring<P: GeomProcessor>(
     processor.linestring_begin(tagged, linestring.0.len(), idx)?;
     let multi_dim = processor.multi_dim();
     for (idxc, coord) in linestring.0.iter().enumerate() {
-        process_coord(coord, multi_dim, idxc, processor)?
+        process_coord(coord, multi_dim, idxc, processor)?;
     }
     processor.linestring_end(tagged, idx)
 }
@@ -156,7 +156,7 @@ fn process_multilinestring<P: GeomProcessor>(
 ) -> Result<()> {
     processor.multilinestring_begin(multilinestring.0.len(), idx)?;
     for (idxc, linestring) in multilinestring.0.iter().enumerate() {
-        process_linestring(linestring, false, idxc, processor)?
+        process_linestring(linestring, false, idxc, processor)?;
     }
     processor.multilinestring_end(idx)
 }
@@ -169,7 +169,7 @@ fn process_polygon<P: GeomProcessor>(
 ) -> Result<()> {
     processor.polygon_begin(tagged, polygon.0.len(), idx)?;
     for (idxl, linestring_type) in polygon.0.iter().enumerate() {
-        process_linestring(linestring_type, false, idxl, processor)?
+        process_linestring(linestring_type, false, idxl, processor)?;
     }
     processor.polygon_end(tagged, idx)
 }

--- a/geozero/tests/postgis.rs
+++ b/geozero/tests/postgis.rs
@@ -259,9 +259,7 @@ mod postgis_sqlx {
 
         let mut tx = pool.begin().await?;
 
-        let _ = sqlx::query!("DELETE FROM point2d",)
-            .execute(&mut tx)
-            .await?;
+        let _ = sqlx::query!("DELETE FROM point2d").execute(&mut tx).await?;
 
         let rec = sqlx::query!("SELECT count(*) as count FROM point2d")
             .fetch_one(&mut tx)


### PR DESCRIPTION
* Bump edition to 2021 (makes no sense to stay on 2018 when geo is on 2021)
* use `r#"raw strings"#` instead of escaping quotes for readability
* removed unneeded empty iter handling