### PR TITLE
Inline format args and optimize comma case

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ while let Some(feature) = fgb.next()? {
     if let Ok(Geometry::MultiPolygon(mpoly)) = feature.to_geo() {
         if let Some(poly) = &mpoly.0.iter().next() {
             let label_pos = polylabel(&poly, &0.10).unwrap();
-            println!("{}: {:?}", name, label_pos);
+            println!("{name}: {label_pos:?}");
         }
     }
 }

--- a/geozero-bench/benches/geobench.rs
+++ b/geozero-bench/benches/geobench.rs
@@ -40,7 +40,7 @@ mod fgb {
         bbox: &Option<Extent>,
         count: usize,
     ) -> Result<()> {
-        let url = format!("http://127.0.0.1:3333/{}", fname);
+        let url = format!("http://127.0.0.1:3333/{fname}");
         let opened_fgb = HttpFgbReader::open(&url).await?;
         let mut selected_fgb = if let Some(bbox) = bbox {
             opened_fgb
@@ -78,11 +78,11 @@ mod postgis_postgres {
         srid: i32,
         count: usize,
     ) -> std::result::Result<(), postgres::error::Error> {
-        let mut sql = format!("SELECT geom FROM {}", table);
+        let mut sql = format!("SELECT geom FROM {table}");
         if let Some(bbox) = bbox {
             sql += &format!(
-                " WHERE geom && ST_MakeEnvelope({}, {}, {}, {}, {})",
-                bbox.minx, bbox.miny, bbox.maxx, bbox.maxy, srid
+                " WHERE geom && ST_MakeEnvelope({}, {}, {}, {}, {srid})",
+                bbox.minx, bbox.miny, bbox.maxx, bbox.maxy
             );
         }
 
@@ -109,11 +109,11 @@ mod rust_postgis {
         srid: i32,
         count: usize,
     ) -> std::result::Result<(), postgres::error::Error> {
-        let mut sql = format!("SELECT geom FROM {}", table);
+        let mut sql = format!("SELECT geom FROM {table}");
         if let Some(bbox) = bbox {
             sql += &format!(
-                " WHERE geom && ST_MakeEnvelope({}, {}, {}, {}, {})",
-                bbox.minx, bbox.miny, bbox.maxx, bbox.maxy, srid
+                " WHERE geom && ST_MakeEnvelope({}, {}, {}, {}, {srid})",
+                bbox.minx, bbox.miny, bbox.maxx, bbox.maxy
             );
         }
 
@@ -149,11 +149,11 @@ mod postgis_sqlx {
         srid: i32,
         count: usize,
     ) -> std::result::Result<(), sqlx::Error> {
-        let mut sql = format!("SELECT geom FROM {}", table);
+        let mut sql = format!("SELECT geom FROM {table}");
         if let Some(bbox) = bbox {
             sql += &format!(
-                " WHERE geom && ST_MakeEnvelope({}, {}, {}, {}, {})",
-                bbox.minx, bbox.miny, bbox.maxx, bbox.maxy, srid
+                " WHERE geom && ST_MakeEnvelope({}, {}, {}, {}, {srid})",
+                bbox.minx, bbox.miny, bbox.maxx, bbox.maxy
             );
         }
         let mut cursor = sqlx::query(&sql).fetch(conn);
@@ -187,16 +187,16 @@ mod gpkg {
         bbox: &Option<Extent>,
         count: usize,
     ) -> std::result::Result<(), sqlx::Error> {
-        let mut conn = SqliteConnection::connect(&format!("sqlite://{}", fpath)).await?;
+        let mut conn = SqliteConnection::connect(&format!("sqlite://{fpath}")).await?;
 
         // http://erouault.blogspot.com/2017/03/dealing-with-huge-vector-geopackage.html
-        let mut sql = format!("SELECT geom FROM {}", table);
+        let mut sql = format!("SELECT geom FROM {table}");
         if let Some(bbox) = bbox {
             sql += &format!(
-                " JOIN rtree_{}_geom r ON {}.fid = r.id
+                " JOIN rtree_{table}_geom r ON {table}.fid = r.id
                     WHERE r.minx <= {} AND r.maxx >= {} AND
                           r.miny <= {} AND r.maxy >= {}",
-                table, table, bbox.maxx, bbox.minx, bbox.maxy, bbox.miny
+                bbox.maxx, bbox.minx, bbox.maxy, bbox.miny
             );
         }
         let mut cursor = sqlx::query(&sql).fetch(&mut conn);

--- a/geozero-cli/src/main.rs
+++ b/geozero-cli/src/main.rs
@@ -179,6 +179,6 @@ fn main() {
         process(args).map_err(|e| e.to_string())
     };
     if let Err(msg) = result {
-        println!("Processing failed: {}", msg);
+        println!("Processing failed: {msg}");
     }
 }

--- a/geozero-shp/src/property_processor.rs
+++ b/geozero-shp/src/property_processor.rs
@@ -19,7 +19,7 @@ impl FeatureProperties for ShapeRecord {
                     processor.property(i, name, &ColumnValue::Bool(*val))?
                 }
                 FieldValue::Date(Some(_)) => {
-                    let s = format!("{}", value);
+                    let s = value.to_string();
                     processor.property(i, name, &ColumnValue::DateTime(&s))?
                 }
                 FieldValue::Float(Some(val)) => {
@@ -33,7 +33,7 @@ impl FeatureProperties for ShapeRecord {
                     processor.property(i, name, &ColumnValue::Double(*val))?
                 }
                 FieldValue::DateTime(_) => {
-                    let s = format!("{}", value);
+                    let s = value.to_string();
                     processor.property(i, name, &ColumnValue::DateTime(&s))?
                 }
                 FieldValue::Memo(val) => processor.property(i, name, &ColumnValue::String(val))?,

--- a/geozero-shp/tests/reader.rs
+++ b/geozero-shp/tests/reader.rs
@@ -153,11 +153,9 @@ fn property_file() -> Result<(), geozero_shp::Error> {
                 'I' => String::from("INTEGER"),
                 'B' => String::from("REAL"),
                 'M' => String::from("BLOB"),
-                _ => {
-                    unimplemented!();
-                }
+                _ => unimplemented!(),
             };
-            format!("{} {}", name, sql_type)
+            format!("{name} {sql_type}")
         })
         .collect::<Vec<String>>()
         .join(",");

--- a/geozero/src/csv/csv_reader.rs
+++ b/geozero/src/csv/csv_reader.rs
@@ -128,12 +128,7 @@ pub fn process_csv_geom(
             |e| {
                 // +2 to start at line 1 and to account for the header row
                 let line = record_idx + 2;
-                log::warn!(
-                    "line {}: invalid WKT: '{}', record: {:?}",
-                    line,
-                    geometry_field,
-                    &record
-                );
+                log::warn!("line {line}: invalid WKT: '{geometry_field}', record: {record:?}");
                 e
             },
         )?;
@@ -190,12 +185,7 @@ pub fn process_csv_features(
                 |e| {
                     // +2 to start at line 1 and to account for the header row
                     let line = feature_idx + 2;
-                    log::warn!(
-                        "line {}: invalid WKT: '{}', record: {:?}",
-                        line,
-                        geometry_field,
-                        &record
-                    );
+                    log::warn!("line {line}: invalid WKT: '{geometry_field}', record: {record:?}");
                     e
                 },
             )?;

--- a/geozero/src/geojson/geojson_writer.rs
+++ b/geozero/src/geojson/geojson_writer.rs
@@ -31,7 +31,7 @@ impl<W: Write> FeatureProcessor for GeoJsonWriter<'_, W> {
 "type": "FeatureCollection""#,
         )?;
         if let Some(name) = name {
-            write!(self.out, ",\n\"name\": \"{}\"", name)?;
+            write!(self.out, ",\n\"name\": \"{name}\"")?;
         }
         self.out.write_all(
             br#",
@@ -77,7 +77,7 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
     }
     fn xy(&mut self, x: f64, y: f64, idx: usize) -> Result<()> {
         self.comma(idx)?;
-        self.out.write_all(format!("[{},{}]", x, y).as_bytes())?;
+        self.out.write_all(format!("[{x},{y}]").as_bytes())?;
         Ok(())
     }
     fn coordinate(
@@ -91,9 +91,9 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
         idx: usize,
     ) -> Result<()> {
         self.comma(idx)?;
-        self.out.write_all(format!("[{},{}", x, y).as_bytes())?;
+        self.out.write_all(format!("[{x},{y}").as_bytes())?;
         if let Some(z) = z {
-            self.out.write_all(format!(",{}", z).as_bytes())?;
+            self.out.write_all(format!(",{z}").as_bytes())?;
         }
         self.out.write_all(b"]")?;
         Ok(())
@@ -187,19 +187,15 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
 }
 
 fn write_num_prop<W: Write>(out: &mut W, colname: &str, v: &dyn Display) -> Result<()> {
-    out.write_all(format!(r#""{}": {v}"#, colname.replace('\"', "\\\"")).as_bytes())?;
+    let colname = colname.replace('\"', "\\\"");
+    out.write_all(format!(r#""{colname}": {v}"#).as_bytes())?;
     Ok(())
 }
 
 fn write_str_prop<W: Write>(out: &mut W, colname: &str, v: &str) -> Result<()> {
-    out.write_all(
-        format!(
-            r#""{}": "{}""#,
-            colname.replace('\"', "\\\""),
-            v.replace('\"', "\\\"")
-        )
-        .as_bytes(),
-    )?;
+    let colname = colname.replace('\"', "\\\"");
+    let value = v.replace('\"', "\\\"");
+    out.write_all(format!(r#""{colname}": "{value}""#).as_bytes())?;
     Ok(())
 }
 

--- a/geozero/src/geometry_processor.rs
+++ b/geozero/src/geometry_processor.rs
@@ -59,7 +59,7 @@ impl CoordDimensions {
 ///
 /// impl GeomProcessor for CoordPrinter {
 ///     fn xy(&mut self, x: f64, y: f64, _idx: usize) -> Result<()> {
-///         Ok(println!("({} {})", x, y))
+///         Ok(println!("({x} {y})"))
 ///     }
 /// }
 /// ```

--- a/geozero/src/mvt/mvt_reader.rs
+++ b/geozero/src/mvt/mvt_reader.rs
@@ -40,11 +40,11 @@ fn process_properties(
         let key = layer
             .keys
             .get(key_idx as usize)
-            .ok_or_else(|| GeozeroError::Feature(format!("invalid key index {}", key_idx)))?;
+            .ok_or_else(|| GeozeroError::Feature(format!("invalid key index {key_idx}")))?;
         let value = layer
             .values
             .get(value_idx as usize)
-            .ok_or_else(|| GeozeroError::Feature(format!("invalid value index {}", value_idx)))?;
+            .ok_or_else(|| GeozeroError::Feature(format!("invalid value index {value_idx}")))?;
 
         if let Some(ref v) = value.string_value {
             processor.property(i, key, &ColumnValue::String(v))?;
@@ -62,8 +62,7 @@ fn process_properties(
             processor.property(i, key, &ColumnValue::Bool(v))?;
         } else {
             return Err(GeozeroError::Property(format!(
-                "unsupported value type for key {}",
-                key
+                "unsupported value type for key {key}",
             )));
         }
     }

--- a/geozero/src/property_processor.rs
+++ b/geozero/src/property_processor.rs
@@ -33,7 +33,7 @@ pub enum ColumnValue<'a> {
 ///
 /// impl PropertyProcessor for PropertyPrinter {
 ///     fn property(&mut self, i: usize, n: &str, v: &ColumnValue) -> Result<bool> {
-///         println!("columnidx: {} name: {} value: {:?}", i, n, v);
+///         println!("columnidx: {i} name: {n} value: {v:?}");
 ///         Ok(false) // don't abort
 ///     }
 /// }
@@ -49,20 +49,20 @@ pub trait PropertyProcessor {
 impl fmt::Display for ColumnValue<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ColumnValue::Byte(v) => write!(f, "{}", v),
-            ColumnValue::UByte(v) => write!(f, "{}", v),
-            ColumnValue::Bool(v) => write!(f, "{}", v),
-            ColumnValue::Short(v) => write!(f, "{}", v),
-            ColumnValue::UShort(v) => write!(f, "{}", v),
-            ColumnValue::Int(v) => write!(f, "{}", v),
-            ColumnValue::UInt(v) => write!(f, "{}", v),
-            ColumnValue::Long(v) => write!(f, "{}", v),
-            ColumnValue::ULong(v) => write!(f, "{}", v),
-            ColumnValue::Float(v) => write!(f, "{}", v),
-            ColumnValue::Double(v) => write!(f, "{}", v),
-            ColumnValue::String(v) => write!(f, "{}", v),
-            ColumnValue::Json(v) => write!(f, "{}", v),
-            ColumnValue::DateTime(v) => write!(f, "{}", v),
+            ColumnValue::Byte(v) => write!(f, "{v}"),
+            ColumnValue::UByte(v) => write!(f, "{v}"),
+            ColumnValue::Bool(v) => write!(f, "{v}"),
+            ColumnValue::Short(v) => write!(f, "{v}"),
+            ColumnValue::UShort(v) => write!(f, "{v}"),
+            ColumnValue::Int(v) => write!(f, "{v}"),
+            ColumnValue::UInt(v) => write!(f, "{v}"),
+            ColumnValue::Long(v) => write!(f, "{v}"),
+            ColumnValue::ULong(v) => write!(f, "{v}"),
+            ColumnValue::Float(v) => write!(f, "{v}"),
+            ColumnValue::Double(v) => write!(f, "{v}"),
+            ColumnValue::String(v) | ColumnValue::Json(v) | ColumnValue::DateTime(v) => {
+                write!(f, "{v}")
+            }
             ColumnValue::Binary(_v) => write!(f, "[BINARY]"),
         }
     }

--- a/geozero/src/svg/writer.rs
+++ b/geozero/src/svg/writer.rs
@@ -45,19 +45,13 @@ impl<W: Write> FeatureProcessor for SvgWriter<'_, W> {
         )?;
         if let Some((width, height)) = self.size {
             self.out
-                .write_all(format!("width=\"{}\" height=\"{}\" ", width, height).as_bytes())?;
+                .write_all(format!(r#"width="{width}" height="{height}" "#).as_bytes())?;
         }
         if let Some((xmin, ymin, xmax, ymax)) = self.view_box {
-            self.out.write_all(
-                format!(
-                    "viewBox=\"{} {} {} {}\" ",
-                    xmin,
-                    ymin,
-                    xmax - xmin,
-                    ymax - ymin
-                )
-                .as_bytes(),
-            )?;
+            let dx = xmax - xmin;
+            let dy = ymax - ymin;
+            self.out
+                .write_all(format!(r#"viewBox="{xmin} {ymin} {dx} {dy}" "#).as_bytes())?;
         }
         self.out.write_all(
             br#"stroke-linecap="round" stroke-linejoin="round">
@@ -85,7 +79,7 @@ impl<W: Write> FeatureProcessor for SvgWriter<'_, W> {
 impl<W: Write> GeomProcessor for SvgWriter<'_, W> {
     fn xy(&mut self, x: f64, y: f64, _idx: usize) -> Result<()> {
         let y = if self.invert_y { -y } else { y };
-        self.out.write_all(format!("{} {} ", x, y).as_bytes())?;
+        self.out.write_all(format!("{x} {y} ").as_bytes())?;
         Ok(())
     }
     fn point_begin(&mut self, _idx: usize) -> Result<()> {

--- a/geozero/src/tessellator/tessellator.rs
+++ b/geozero/src/tessellator/tessellator.rs
@@ -125,7 +125,7 @@ pub struct ObjWriter;
 
 impl VertexOutput for ObjWriter {
     fn vertex(&self, x: f32, y: f32, z: f32) {
-        println!("v {} {} {}", x, y, z);
+        println!("v {x} {y} {z}");
     }
     fn triangle(&self, idx0: u16, idx1: u16, idx2: u16) {
         println!("f {} {} {}", idx0 + 1, idx1 + 1, idx2 + 1);

--- a/geozero/src/wkt/wkt_writer.rs
+++ b/geozero/src/wkt/wkt_writer.rs
@@ -43,14 +43,15 @@ impl<W: Write> GeomProcessor for WktWriter<'_, W> {
     fn dimensions(&self) -> CoordDimensions {
         self.dims
     }
+
     fn xy(&mut self, x: f64, y: f64, idx: usize) -> Result<()> {
-        if idx == 0 {
-            self.out.write_all(format!("{} {}", x, y).as_bytes())?;
-        } else {
-            self.out.write_all(format!(",{} {}", x, y).as_bytes())?;
+        if idx > 0 {
+            self.out.write_all(b",")?;
         }
+        self.out.write_all(format!("{x} {y}").as_bytes())?;
         Ok(())
     }
+
     fn coordinate(
         &mut self,
         x: f64,
@@ -61,16 +62,15 @@ impl<W: Write> GeomProcessor for WktWriter<'_, W> {
         _tm: Option<u64>,
         idx: usize,
     ) -> Result<()> {
-        if idx == 0 {
-            self.out.write_all(format!("{} {}", x, y).as_bytes())?;
-        } else {
-            self.out.write_all(format!(",{} {}", x, y).as_bytes())?;
+        if idx > 0 {
+            self.out.write_all(b",")?;
         }
+        self.out.write_all(format!("{x} {y}").as_bytes())?;
         if let Some(z) = z {
-            self.out.write_all(format!(" {}", z).as_bytes())?;
+            self.out.write_all(format!(" {z}").as_bytes())?;
         }
         if let Some(m) = m {
-            self.out.write_all(format!(" {}", m).as_bytes())?;
+            self.out.write_all(format!(" {m}").as_bytes())?;
         }
         Ok(())
     }

--- a/geozero/tests/polylabel.rs
+++ b/geozero/tests/polylabel.rs
@@ -16,7 +16,7 @@ fn country_labels() -> Result<()> {
         if let Ok(Geometry::MultiPolygon(mpoly)) = feature.to_geo() {
             if let Some(poly) = &mpoly.0.first() {
                 let label_pos = polylabel(poly, &0.10).unwrap();
-                println!("{}: {:?}", name, label_pos);
+                println!("{name}: {label_pos:?}");
                 if !vec!["Bermuda", "Falkland Islands"].contains(&name.as_str()) {
                     assert!(mpoly.contains(&label_pos));
                 }

--- a/geozero/tests/svg.rs
+++ b/geozero/tests/svg.rs
@@ -11,7 +11,7 @@ use std::io::Write;
 fn json_to_svg() -> Result<()> {
     let mut f = File::open("tests/data/places.json")?;
     let svg = GeoJsonReader(&mut f).to_svg().unwrap();
-    println!("{}", &svg);
+    println!("{svg}");
     assert_eq!(
         &svg[svg.len() - 100..],
         r#"387481909902 1.294979325105942 Z"/>


### PR DESCRIPTION
* Make `format!` style arg a bit more streamlined and readable.
* One of the cases had a duplicate logic juts to print an extra comma - made it a bit simpler.