### PR TITLE
Tessellator was broken for years! Revert-fixing.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -58,3 +58,10 @@ jobs:
           cargo test --workspace --all-features
           cargo test --manifest-path geozero/Cargo.toml
           cargo test --manifest-path geozero/Cargo.toml --no-default-features
+
+      - name: Ensure valid cfg usage
+        if: matrix.version == 'stable'
+        run: |
+          rustup toolchain install nightly
+          export RUSTFLAGS='-D warnings'
+          cargo +nightly check -Z unstable-options -Z check-cfg=features,names,values,output --workspace --all-features

--- a/geozero/Cargo.toml
+++ b/geozero/Cargo.toml
@@ -40,7 +40,7 @@ geos = { version = "8.1", optional = true }
 gdal = { version = "0.14", default-features = false, optional = true }
 gdal-sys = { version = "0.8", optional = true }
 gpx = { version = "0.8", default-features = false, optional = true }
-lyon = { version = "1.0", optional = true }
+lyon = { version = "0.16.2", optional = true }
 log = "0.4.17"
 scroll = { version = "0.11", optional = true }
 sqlx = { version = "0.6", default-features = false, optional = true }

--- a/geozero/src/lib.rs
+++ b/geozero/src/lib.rs
@@ -105,7 +105,7 @@ pub mod svg;
 #[cfg(feature = "with-svg")]
 pub use crate::svg::conversion::*;
 
-#[cfg(feature = "with-tesselator")]
+#[cfg(feature = "with-tessellator")]
 pub mod tessellator;
 
 #[cfg(feature = "with-wkb")]

--- a/geozero/src/tessellator/tessellator.rs
+++ b/geozero/src/tessellator/tessellator.rs
@@ -135,7 +135,7 @@ impl VertexOutput for ObjWriter {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::geojson_reader::read_geojson;
+    use crate::geojson::geojson_reader::read_geojson;
 
     #[test]
     fn point_geom() {


### PR DESCRIPTION
* Due to a typo in the cfg flag, tessellator was never built properly (we can even remove it as it is clearly not being used by anyone).
* This is a known issues in the rust compiler: https://github.com/rust-lang/cargo/issues/10554
* I reverted Lyon to 0.16.2 and it worked fine.
* I added a CI nightly `check` step to make sure this won't happen again

Do we want to keep this and spend the effort to upgrade to the latest Lyon crate, or is this a useless feature and should be removed?