### PR TITLE
Implement MVT tag builder

### DIFF
--- a/geozero/Cargo.toml
+++ b/geozero/Cargo.toml
@@ -15,20 +15,20 @@ categories = ["Geospatial"]
 default = ["with-svg", "with-wkt", "with-geo", "with-geojson"]
 with-arrow = ["arrow2"]
 with-csv = ["csv", "with-wkt"]
-with-svg = []
-with-wkt = ["wkt"]
+with-gdal = ["gdal", "gdal-sys"]
 with-geo = ["geo-types"]
 with-geojson = ["geojson"]
-with-gdal = ["gdal", "gdal-sys"]
 with-geos = ["geos"]
-with-wkb = ["scroll", "with-wkt"]
 with-gpkg = ["with-wkb", "sqlx/sqlite"]
 with-gpx = ["gpx"]
-with-postgis-sqlx = ["with-wkb", "sqlx/postgres"]
-with-postgis-postgres = ["with-wkb", "postgres-types", "bytes"]
+with-mvt = ["prost", "prost-build", "dup-indexer"]
 with-postgis-diesel = ["with-wkb", "diesel", "byteorder"]
-with-mvt = ["prost", "prost-build"]
+with-postgis-postgres = ["with-wkb", "postgres-types", "bytes"]
+with-postgis-sqlx = ["with-wkb", "sqlx/postgres"]
+with-svg = []
 with-tessellator = ["lyon"]
+with-wkb = ["scroll", "with-wkt"]
+with-wkt = ["wkt"]
 
 [dependencies]
 arrow2 = { version = "0.17", optional = true, features = ["io_ipc"] }
@@ -36,6 +36,7 @@ byteorder = { version = "1.4.3", default-features = false, optional = true }
 bytes = { version = "1.4", optional = true }
 csv = { version = "1.2.1", optional = true }
 diesel = { version = "2.0.2", default-features = false, optional = true }
+dup-indexer = { version = "0.2", optional = true }
 gdal = { version = "0.14", default-features = false, optional = true }
 gdal-sys = { version = "0.8", optional = true }
 geo-types = { version = "0.7", default-features = false, optional = true }

--- a/geozero/src/mvt/mod.rs
+++ b/geozero/src/mvt/mod.rs
@@ -2,6 +2,13 @@
 mod mvt_commands;
 pub(crate) mod mvt_reader;
 pub(crate) mod mvt_writer;
+
+mod tag_builder;
+pub use tag_builder::TagsBuilder;
+
+mod tile_value;
+pub use tile_value::TileValue;
+
 #[rustfmt::skip]
 mod vector_tile;
 

--- a/geozero/src/mvt/tile_value.rs
+++ b/geozero/src/mvt/tile_value.rs
@@ -1,0 +1,92 @@
+use crate::mvt::tile::Value;
+use std::hash::Hash;
+
+/// A wrapper for the MVT value types.
+#[derive(Debug, Clone, PartialEq)]
+pub enum TileValue {
+    Str(String),
+    Float(f32),
+    Double(f64),
+    Int(i64),
+    Uint(u64),
+    Sint(i64),
+    Bool(bool),
+}
+
+impl From<TileValue> for Value {
+    fn from(tv: TileValue) -> Self {
+        match tv {
+            TileValue::Str(s) => Self {
+                string_value: Some(s),
+                ..Default::default()
+            },
+            TileValue::Float(f) => Self {
+                float_value: Some(f),
+                ..Default::default()
+            },
+            TileValue::Double(d) => Self {
+                double_value: Some(d),
+                ..Default::default()
+            },
+            TileValue::Int(i) => Self {
+                int_value: Some(i),
+                ..Default::default()
+            },
+            TileValue::Uint(u) => Self {
+                uint_value: Some(u),
+                ..Default::default()
+            },
+            TileValue::Sint(i) => Self {
+                sint_value: Some(i),
+                ..Default::default()
+            },
+            TileValue::Bool(b) => Self {
+                bool_value: Some(b),
+                ..Default::default()
+            },
+        }
+    }
+}
+
+impl TryFrom<Value> for TileValue {
+    type Error = ();
+
+    fn try_from(v: Value) -> Result<Self, Self::Error> {
+        Ok(if let Some(s) = v.string_value {
+            Self::Str(s)
+        } else if let Some(f) = v.float_value {
+            Self::Float(f)
+        } else if let Some(d) = v.double_value {
+            Self::Double(d)
+        } else if let Some(i) = v.int_value {
+            Self::Int(i)
+        } else if let Some(u) = v.uint_value {
+            Self::Uint(u)
+        } else if let Some(i) = v.sint_value {
+            Self::Sint(i)
+        } else if let Some(b) = v.bool_value {
+            Self::Bool(b)
+        } else {
+            Err(())?
+        })
+    }
+}
+
+// Treat floats as bits so that we can use as keys.
+// It is up to the users to ensure that the bits are not NaNs, or are consistent.
+
+impl Eq for TileValue {}
+
+impl Hash for TileValue {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Str(s) => s.hash(state),
+            Self::Float(f) => f.to_bits().hash(state),
+            Self::Double(d) => d.to_bits().hash(state),
+            Self::Int(i) => i.hash(state),
+            Self::Uint(u) => u.hash(state),
+            Self::Sint(i) => i.hash(state),
+            Self::Bool(b) => b.hash(state),
+        }
+    }
+}


### PR DESCRIPTION
* Implement a new TagBuilder struct that accumulates keys and values with stable indexes, and once finished, can be used to serialize the MVT lookup tables.
* Implement TileValue enum to simplify and speed up access to the MVT values
* Some minor testing and other MVT cleanups
* Sort cargo features