### PR TITLE
Upgrade to dup-indexer v0.3

### DIFF
--- a/geozero/Cargo.toml
+++ b/geozero/Cargo.toml
@@ -36,7 +36,7 @@ byteorder = { version = "1.4.3", default-features = false, optional = true }
 bytes = { version = "1.4", optional = true }
 csv = { version = "1.2.1", optional = true }
 diesel = { version = "2.0.2", default-features = false, optional = true }
-dup-indexer = { version = "0.2", optional = true }
+dup-indexer = { version = "0.3", optional = true }
 gdal = { version = "0.14", default-features = false, optional = true }
 gdal-sys = { version = "0.8", optional = true }
 geo-types = { version = "0.7.9", default-features = false, optional = true }

--- a/geozero/src/mvt/tag_builder.rs
+++ b/geozero/src/mvt/tag_builder.rs
@@ -1,5 +1,5 @@
 use crate::mvt::tile_value::TileValue;
-use dup_indexer::DupIndexer;
+use dup_indexer::{DupIndexer, PtrRead};
 use std::hash::Hash;
 
 /// A builder for key-value pairs, where the key is a `String` or `&str`, and the value is a
@@ -22,13 +22,17 @@ pub struct TagsBuilder<K> {
     values: DupIndexer<TileValue>,
 }
 
-impl<K: Default + Eq + Hash> Default for TagsBuilder<K> {
+/// This is safe because all values are either simple bit-readable values or strings,
+/// both of which are safe for `PtrRead`.
+unsafe impl PtrRead for TileValue {}
+
+impl<K: Default + Eq + Hash + PtrRead> Default for TagsBuilder<K> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<K: Eq + Hash> TagsBuilder<K> {
+impl<K: Eq + Hash + PtrRead> TagsBuilder<K> {
     pub fn new() -> Self {
         Self {
             keys: DupIndexer::new(),


### PR DESCRIPTION
Dup indexer now requires values to implement unsafe `PtrRead` marker trait, as it doesn't seem to work for Box values.  Our use cases do not require such values.