### PR TITLE
RFC: Drop lifetime parameter of GeoJsonReader

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,11 +26,10 @@ jobs:
       - name: Install protoc
         uses: arduino/setup-protoc@v1
 
-      - name: Format, Check, Clippy
+      - name: Format, Clippy
         shell: bash
         run: |
           cargo fmt --all -- --check
-          cargo check --workspace --all-features --bins --examples --tests --benches
           cargo clippy --workspace --all-features --bins --examples --tests --benches -- -D warnings
 
       - name: Tests

--- a/geozero-cli/src/main.rs
+++ b/geozero-cli/src/main.rs
@@ -67,7 +67,7 @@ fn transform<P: FeatureProcessor>(args: Cli, processor: &mut P) -> Result<()> {
             GeozeroDatasource::process(&mut ds, processor)?;
         }
         Some("json") | Some("geojson") => {
-            let mut ds = GeoJsonReader(&mut filein);
+            let mut ds = GeoJsonReader(filein);
             GeozeroDatasource::process(&mut ds, processor)?;
         }
         Some("fgb") => {

--- a/geozero/src/geojson/geojson_reader.rs
+++ b/geozero/src/geojson/geojson_reader.rs
@@ -41,9 +41,9 @@ impl GeozeroDatasource for GeoJson<'_> {
 }
 
 /// GeoJSON Reader.
-pub struct GeoJsonReader<'a, R: Read>(pub &'a mut R);
+pub struct GeoJsonReader<R: Read>(pub R);
 
-impl<'a, R: Read> GeozeroDatasource for GeoJsonReader<'a, R> {
+impl<R: Read> GeozeroDatasource for GeoJsonReader<R> {
     fn process<P: FeatureProcessor>(&mut self, processor: &mut P) -> Result<()> {
         read_geojson(&mut self.0, processor)
     }

--- a/geozero/src/lib.rs
+++ b/geozero/src/lib.rs
@@ -129,8 +129,8 @@ pub use crate::mvt::conversion::*;
 pub struct ProcessorSink;
 
 impl ProcessorSink {
-    pub fn new() -> ProcessorSink {
-        Self::default()
+    pub fn new() -> Self {
+        Self
     }
 }
 

--- a/geozero/tests/kdbush.rs
+++ b/geozero/tests/kdbush.rs
@@ -19,8 +19,8 @@ impl geozero::GeomProcessor for PointIndex {
 
 #[test]
 fn create() -> Result<()> {
-    let mut f = File::open("tests/data/places.json")?;
-    let mut reader = GeoJsonReader(&mut f);
+    let f = File::open("tests/data/places.json")?;
+    let mut reader = GeoJsonReader(f);
     let mut points = PointIndex {
         pos: 0,
         index: KDBush::new(1249, DEFAULT_NODE_SIZE),

--- a/geozero/tests/svg.rs
+++ b/geozero/tests/svg.rs
@@ -9,8 +9,8 @@ use std::io::Write;
 
 #[test]
 fn json_to_svg() -> Result<()> {
-    let mut f = File::open("tests/data/places.json")?;
-    let svg = GeoJsonReader(&mut f).to_svg().unwrap();
+    let f = File::open("tests/data/places.json")?;
+    let svg = GeoJsonReader(f).to_svg().unwrap();
     println!("{svg}");
     assert_eq!(
         &svg[svg.len() - 100..],


### PR DESCRIPTION
`&'a mut R` implements `Read` if `R` does so this should not reduce the set of supported types but it avoids forcing the user to provide a borrowed reference and allow taking ownership as well.