### PR TITLE
Improve WkbWriter constructors

### DIFF
--- a/geozero/src/gpkg/geopackage.rs
+++ b/geozero/src/gpkg/geopackage.rs
@@ -53,9 +53,13 @@ impl<T: GeozeroGeometry + Sized> sqlx::Type<Sqlite> for wkb::Encode<T> {
 impl<'q, T: GeozeroGeometry + Sized> Encode<'q, Sqlite> for wkb::Encode<T> {
     fn encode_by_ref(&self, args: &mut Vec<SqliteArgumentValue<'q>>) -> IsNull {
         let mut wkb_out: Vec<u8> = Vec::new();
-        let mut writer = wkb::WkbWriter::new(&mut wkb_out, wkb::WkbDialect::Geopackage);
-        writer.dims = self.0.dims();
-        writer.srid = self.0.srid();
+        let mut writer = wkb::WkbWriter::with_opts(
+            &mut wkb_out,
+            wkb::WkbDialect::Geopackage,
+            self.0.dims(),
+            self.0.srid(),
+            Vec::new(),
+        );
         self.0
             .process_geom(&mut writer)
             .expect("Failed to encode Geometry");
@@ -119,10 +123,13 @@ macro_rules! impl_sqlx_gpkg_encode {
             ) -> sqlx::encode::IsNull {
                 use $crate::GeozeroGeometry;
                 let mut wkb_out: Vec<u8> = Vec::new();
-                let mut writer =
-                    $crate::wkb::WkbWriter::new(&mut wkb_out, $crate::wkb::WkbDialect::Geopackage);
-                writer.dims = self.dims();
-                writer.srid = self.srid();
+                let mut writer = $crate::wkb::WkbWriter::with_opts(
+                    &mut wkb_out,
+                    $crate::wkb::WkbDialect::Geopackage,
+                    self.dims(),
+                    self.srid(),
+                    Vec::new(),
+                );
                 self.process_geom(&mut writer)
                     .expect("Failed to encode Geometry");
                 args.push(sqlx::sqlite::SqliteArgumentValue::Blob(

--- a/geozero/src/postgis/postgis_postgres.rs
+++ b/geozero/src/postgis/postgis_postgres.rs
@@ -42,9 +42,13 @@ impl<T: GeozeroGeometry + Sized> ToSql for wkb::Encode<T> {
         out: &mut BytesMut,
     ) -> Result<IsNull, Box<dyn std::error::Error + Sync + Send>> {
         let pgout = &mut out.writer();
-        let mut writer = wkb::WkbWriter::new(pgout, wkb::WkbDialect::Ewkb);
-        writer.dims = self.0.dims();
-        writer.srid = self.0.srid();
+        let mut writer = wkb::WkbWriter::with_opts(
+            pgout,
+            wkb::WkbDialect::Ewkb,
+            self.0.dims(),
+            self.0.srid(),
+            Vec::new(),
+        );
         self.0.process_geom(&mut writer)?;
         Ok(IsNull::No)
     }
@@ -103,9 +107,13 @@ macro_rules! impl_postgres_postgis_encode {
                 use bytes::BufMut;
 
                 let pgout = &mut out.writer();
-                let mut writer = $crate::wkb::WkbWriter::new(pgout, $crate::wkb::WkbDialect::Ewkb);
-                writer.dims = self.dims();
-                writer.srid = self.srid();
+                let mut writer = $crate::wkb::WkbWriter::with_opts(
+                    pgout,
+                    $crate::wkb::WkbDialect::Ewkb,
+                    self.dims(),
+                    self.srid(),
+                    Vec::new(),
+                );
                 self.process_geom(&mut writer)?;
                 Ok(postgres_types::IsNull::No)
             }

--- a/geozero/src/wkb/mod.rs
+++ b/geozero/src/wkb/mod.rs
@@ -91,10 +91,7 @@ pub(crate) mod conversion {
             envelope: Vec<f64>,
         ) -> Result<Vec<u8>> {
             let mut wkb: Vec<u8> = Vec::new();
-            let mut writer = WkbWriter::new(&mut wkb, dialect);
-            writer.dims = dims;
-            writer.srid = srid;
-            writer.envelope = envelope;
+            let mut writer = WkbWriter::with_opts(&mut wkb, dialect, dims, srid, envelope);
             self.process_geom(&mut writer)?;
             Ok(wkb)
         }

--- a/geozero/src/wkb/wkb_writer.rs
+++ b/geozero/src/wkb/wkb_writer.rs
@@ -6,7 +6,10 @@ use std::io::Write;
 
 /// WKB writer.
 pub struct WkbWriter<W: Write> {
+    /// Coordinate dimensions to write
     dims: CoordDimensions,
+    /// Coordinate dimensions which should be read
+    read_dims: CoordDimensions,
     srid: Option<i32>,
     /// Geometry envelope (GPKG)
     envelope: Vec<f64>,
@@ -35,19 +38,7 @@ impl<W: Write> WkbWriter<W> {
     pub fn new(out: W, dialect: WkbDialect) -> Self {
         let srid = None;
         let envelope = Vec::new();
-        let envelope_dims = CoordDimensions::default();
-        let extended_gpkg = false;
-        let empty = false;
-        Self::with_extended_opts(
-            out,
-            dialect,
-            CoordDimensions::default(),
-            srid,
-            envelope,
-            envelope_dims,
-            extended_gpkg,
-            empty,
-        )
+        Self::with_opts(out, dialect, CoordDimensions::default(), srid, envelope)
     }
 
     pub fn with_opts(
@@ -57,6 +48,7 @@ impl<W: Write> WkbWriter<W> {
         srid: Option<i32>,
         envelope: Vec<f64>,
     ) -> Self {
+        let read_dims = dims;
         let envelope_dims = CoordDimensions::default();
         let extended_gpkg = false;
         let empty = false;
@@ -64,6 +56,7 @@ impl<W: Write> WkbWriter<W> {
             out,
             dialect,
             dims,
+            read_dims,
             srid,
             envelope,
             envelope_dims,
@@ -72,10 +65,12 @@ impl<W: Write> WkbWriter<W> {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn with_extended_opts(
         out: W,
         dialect: WkbDialect,
         dims: CoordDimensions,
+        read_dims: CoordDimensions,
         srid: Option<i32>,
         envelope: Vec<f64>,
         envelope_dims: CoordDimensions,
@@ -84,6 +79,7 @@ impl<W: Write> WkbWriter<W> {
     ) -> Self {
         WkbWriter {
             dims,
+            read_dims,
             srid,
             envelope,
             envelope_dims,
@@ -268,15 +264,10 @@ impl<W: Write> WkbWriter<W> {
 
 impl<W: Write> GeomProcessor for WkbWriter<W> {
     fn dimensions(&self) -> CoordDimensions {
-        self.dims
+        self.read_dims
     }
-    fn xy(&mut self, x: f64, y: f64, _idx: usize) -> Result<()> {
-        if self.geom_state == GeomState::MultiPointGeom {
-            self.write_header(WKBGeometryType::Point)?;
-        }
-        self.out.iowrite_with(x, self.endian)?;
-        self.out.iowrite_with(y, self.endian)?;
-        Ok(())
+    fn xy(&mut self, x: f64, y: f64, idx: usize) -> Result<()> {
+        self.coordinate(x, y, None, None, None, None, idx)
     }
     fn coordinate(
         &mut self,
@@ -293,10 +284,12 @@ impl<W: Write> GeomProcessor for WkbWriter<W> {
         }
         self.out.iowrite_with(x, self.endian)?;
         self.out.iowrite_with(y, self.endian)?;
-        if let Some(z) = z {
+        if self.dims.z {
+            let z = z.unwrap_or(0.0);
             self.out.iowrite_with(z, self.endian)?;
         }
-        if let Some(m) = m {
+        if self.dims.m {
+            let m = m.unwrap_or(0.0);
             self.out.iowrite_with(m, self.endian)?;
         }
         Ok(())
@@ -465,13 +458,38 @@ mod test {
     ) {
         let wkb_in = hex::decode(ewkb_str).unwrap();
         let mut wkb_out: Vec<u8> = Vec::new();
-        let mut writer = WkbWriter::new(&mut wkb_out, dialect);
-        writer.dims = dims;
-        writer.srid = srid;
-        writer.envelope = envelope;
+        let mut writer = WkbWriter::with_opts(&mut wkb_out, dialect, dims, srid, envelope);
         assert!(process_wkb_type_geom(&mut wkb_in.as_slice(), &mut writer, dialect).is_ok());
 
         assert_eq!(hex::encode(wkb_in), hex::encode(wkb_out));
+    }
+
+    fn with_ext_opts(
+        dialect: WkbDialect,
+        dims: CoordDimensions,
+        read_dims: CoordDimensions,
+        srid: Option<i32>,
+        envelope: Vec<f64>,
+        ewkb_str: &str,
+    ) -> String {
+        let wkb_in = hex::decode(ewkb_str).unwrap();
+        let mut wkb_out: Vec<u8> = Vec::new();
+        let envelope_dims = CoordDimensions::default();
+        let extended_gpkg = false;
+        let empty = false;
+        let mut writer = WkbWriter::with_extended_opts(
+            &mut wkb_out,
+            dialect,
+            dims,
+            read_dims,
+            srid,
+            envelope,
+            envelope_dims,
+            extended_gpkg,
+            empty,
+        );
+        assert!(process_wkb_type_geom(&mut wkb_in.as_slice(), &mut writer, dialect).is_ok());
+        hex::encode(wkb_out)
     }
 
     #[test]
@@ -546,6 +564,22 @@ mod test {
         // SELECT 'TRIANGLE((0 0,0 9,9 0,0 0))'::geometry
         roundtrip(Ewkb, DIM_XY, None, Vec::new(),
                   "0111000000010000000400000000000000000000000000000000000000000000000000000000000000000022400000000000002240000000000000000000000000000000000000000000000000");
+    }
+
+    #[test]
+    fn ewkb_flatten_geometry() {
+        // SELECT 'SRID=4326;LINESTRING (10 -20 100, 0 -0.5 101)'::geometry
+        let wkbin = "01020000A0E610000002000000000000000000244000000000000034C000000000000059400000000000000000000000000000E0BF0000000000405940";
+
+        // Read XY and write XYZ
+        let out = with_ext_opts(Ewkb, DIM_XYZ, DIM_XY, Some(4326), Vec::new(), wkbin);
+        // SELECT 'SRID=4326;LINESTRING (10 -20 0, 0 -0.5 0)'::geometry
+        assert_eq!(out, "01020000a0e610000002000000000000000000244000000000000034c000000000000000000000000000000000000000000000e0bf0000000000000000");
+
+        // Read XYZ and write XY
+        let out = with_ext_opts(Ewkb, DIM_XY, DIM_XYZ, Some(4326), Vec::new(), wkbin);
+        // SELECT 'SRID=4326;LINESTRING (10 -20, 0 -0.5)'::geometry
+        assert_eq!(out, "0102000020e610000002000000000000000000244000000000000034c00000000000000000000000000000e0bf");
     }
 
     #[test]

--- a/geozero/src/wkb/wkb_writer.rs
+++ b/geozero/src/wkb/wkb_writer.rs
@@ -6,16 +6,16 @@ use std::io::Write;
 
 /// WKB writer.
 pub struct WkbWriter<W: Write> {
-    pub dims: CoordDimensions,
-    pub srid: Option<i32>,
+    dims: CoordDimensions,
+    srid: Option<i32>,
     /// Geometry envelope (GPKG)
-    pub envelope: Vec<f64>,
+    envelope: Vec<f64>,
     /// Envelope dimensions (GPKG)
-    pub envelope_dims: CoordDimensions,
+    envelope_dims: CoordDimensions,
     /// ExtendedGeoPackageBinary
-    pub extended_gpkg: bool,
+    extended_gpkg: bool,
     /// Empty geometry flag (GPKG)
-    pub empty: bool,
+    empty: bool,
     endian: scroll::Endian,
     dialect: WkbDialect,
     first_header: bool,
@@ -33,13 +33,62 @@ enum GeomState {
 
 impl<W: Write> WkbWriter<W> {
     pub fn new(out: W, dialect: WkbDialect) -> Self {
-        Self {
-            dims: CoordDimensions::default(),
-            srid: None,
-            envelope: Vec::new(),
-            envelope_dims: CoordDimensions::default(),
-            extended_gpkg: false,
-            empty: false,
+        let srid = None;
+        let envelope = Vec::new();
+        let envelope_dims = CoordDimensions::default();
+        let extended_gpkg = false;
+        let empty = false;
+        Self::with_extended_opts(
+            out,
+            dialect,
+            CoordDimensions::default(),
+            srid,
+            envelope,
+            envelope_dims,
+            extended_gpkg,
+            empty,
+        )
+    }
+
+    pub fn with_opts(
+        out: W,
+        dialect: WkbDialect,
+        dims: CoordDimensions,
+        srid: Option<i32>,
+        envelope: Vec<f64>,
+    ) -> Self {
+        let envelope_dims = CoordDimensions::default();
+        let extended_gpkg = false;
+        let empty = false;
+        Self::with_extended_opts(
+            out,
+            dialect,
+            dims,
+            srid,
+            envelope,
+            envelope_dims,
+            extended_gpkg,
+            empty,
+        )
+    }
+
+    pub fn with_extended_opts(
+        out: W,
+        dialect: WkbDialect,
+        dims: CoordDimensions,
+        srid: Option<i32>,
+        envelope: Vec<f64>,
+        envelope_dims: CoordDimensions,
+        extended_gpkg: bool,
+        empty: bool,
+    ) -> Self {
+        WkbWriter {
+            dims,
+            srid,
+            envelope,
+            envelope_dims,
+            extended_gpkg,
+            empty,
             endian: scroll::LE,
             dialect,
             first_header: true,

--- a/geozero/src/wkb/wkb_writer.rs
+++ b/geozero/src/wkb/wkb_writer.rs
@@ -65,6 +65,8 @@ impl<W: Write> WkbWriter<W> {
         )
     }
 
+    #[doc(hidden)]
+    // Temporary constructor. To be replaced with builder pattern.
     #[allow(clippy::too_many_arguments)]
     pub fn with_extended_opts(
         out: W,


### PR DESCRIPTION
This PR adresses #156 (first commit) and should fix different dimensions in reader and writer (second commit).

Follow-up to discussion with @Oreilles in https://github.com/georust/geozero/issues/153#issuecomment-1675943714

Instead of the ugly `with_extended_opts` constructor we should probably use a builder pattern.