### PR TITLE
Fix invalid WKT empty geometries

### DIFF
--- a/geozero/CHANGELOG.md
+++ b/geozero/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+* Breaking: remove `set_dims` from CSVWriter. Instead use `CsvWriter::with_dims` constructor.
+
 ## 0.10.0 (2023-07-07)
 
 * Remove lifetime from `GeoJsonReader`

--- a/geozero/src/wkt/wkt_reader.rs
+++ b/geozero/src/wkt/wkt_reader.rs
@@ -342,6 +342,13 @@ mod test {
         }
 
         #[test]
+        fn empty_line_roundtrip() {
+            let wkt = WktStr("LINESTRING EMPTY");
+            let actual = wkt.to_wkt().unwrap();
+            assert_eq!("LINESTRING EMPTY", &actual);
+        }
+
+        #[test]
         fn empty_multi_line_string() {
             let wkt = WktStr("MULTILINESTRING EMPTY");
             let actual = wkt.to_geo().unwrap();
@@ -350,11 +357,37 @@ mod test {
         }
 
         #[test]
+        fn empty_multi_line_roundtrip() {
+            let wkt = WktStr("MULTILINESTRING EMPTY");
+            let actual = wkt.to_wkt().unwrap();
+            assert_eq!("MULTILINESTRING EMPTY", &actual);
+        }
+
+        #[test]
+        fn multi_line_string_with_empty_one() {
+            let wkt = WktStr("MULTILINESTRING ((10 10, 20 20, 10 40), EMPTY)");
+            let actual = wkt.to_geo().unwrap();
+            // type one line at a time.
+            let expected: geo_types::Geometry<f64> = geo_types::MultiLineString(vec![
+                line_string![(x: 10.0, y: 10.0), (x: 20.0, y: 20.0), (x: 10.0, y: 40.0)],
+                line_string![],
+            ]).into();
+            assert_eq!(expected, actual);
+        }
+    
+        #[test]
         fn empty_polygon() {
             let wkt = WktStr("POLYGON EMPTY");
             let actual = wkt.to_geo().unwrap();
             let expected: geo_types::Geometry<f64> = polygon![].into();
             assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn empty_polygon_roundtrip() {
+            let wkt = WktStr("POLYGON EMPTY");
+            let actual = wkt.to_wkt().unwrap();
+            assert_eq!("POLYGON EMPTY", &actual);
         }
 
         #[test]
@@ -366,6 +399,13 @@ mod test {
         }
 
         #[test]
+        fn empty_multi_polygon_roundtrip() {
+            let wkt = WktStr("MULTIPOLYGON EMPTY");
+            let actual = wkt.to_wkt().unwrap();
+            assert_eq!("MULTIPOLYGON EMPTY", &actual);
+        }
+
+        #[test]
         fn empty_geometry_collection() {
             let wkt = WktStr("GEOMETRYCOLLECTION EMPTY");
             let actual = wkt.to_geo().unwrap();
@@ -373,6 +413,13 @@ mod test {
             let expected =
                 geo_types::Geometry::GeometryCollection(geo_types::GeometryCollection(vec![]));
             assert_eq!(expected, actual);
+        }
+
+        #[test]
+        fn empty_geometry_collection_roundtrip() {
+            let wkt = WktStr("GEOMETRYCOLLECTION EMPTY");
+            let actual = wkt.to_wkt().unwrap();
+            assert_eq!("GEOMETRYCOLLECTION EMPTY", &actual);
         }
     }
 }

--- a/geozero/src/wkt/wkt_reader.rs
+++ b/geozero/src/wkt/wkt_reader.rs
@@ -371,10 +371,11 @@ mod test {
             let expected: geo_types::Geometry<f64> = geo_types::MultiLineString(vec![
                 line_string![(x: 10.0, y: 10.0), (x: 20.0, y: 20.0), (x: 10.0, y: 40.0)],
                 line_string![],
-            ]).into();
+            ])
+            .into();
             assert_eq!(expected, actual);
         }
-    
+
         #[test]
         fn empty_polygon() {
             let wkt = WktStr("POLYGON EMPTY");

--- a/geozero/src/wkt/wkt_writer.rs
+++ b/geozero/src/wkt/wkt_writer.rs
@@ -76,6 +76,8 @@ impl<'a, W: Write> WktWriter<'a, W> {
             if geometry_size > 0 {
                 self.out.write_all(b")")?;
             }
+        } else {
+            debug_assert!(false, "ended geometry that didn't start");
         }
         Ok(())
     }

--- a/geozero/src/wkt/wkt_writer.rs
+++ b/geozero/src/wkt/wkt_writer.rs
@@ -6,32 +6,32 @@ use std::vec;
 use super::WktDialect;
 
 /// WKT Writer.
-pub struct WktWriter<'a, W: Write> {
+pub struct WktWriter<W: Write> {
     dims: CoordDimensions,
     srid: Option<i32>,
     dialect: WktDialect,
     first_header: bool,
     /// Stack of in-progress geometry sizes
     geometry_sizes: Vec<usize>,
-    out: &'a mut W,
+    pub(crate) out: W,
 }
 
-impl<'a, W: Write> WktWriter<'a, W> {
-    pub fn new(out: &'a mut W) -> WktWriter<'a, W> {
+impl<W: Write> WktWriter<W> {
+    pub fn new(out: W) -> Self {
         Self::with_opts(out, WktDialect::Wkt, CoordDimensions::default(), None)
     }
 
-    pub fn with_dims(out: &'a mut W, dims: CoordDimensions) -> WktWriter<'a, W> {
+    pub fn with_dims(out: W, dims: CoordDimensions) -> Self {
         Self::with_opts(out, WktDialect::Wkt, dims, None)
     }
 
     pub fn with_opts(
-        out: &'a mut W,
+        out: W,
         dialect: WktDialect,
         dims: CoordDimensions,
         srid: Option<i32>,
-    ) -> WktWriter<'a, W> {
-        WktWriter {
+    ) -> Self {
+        Self {
             dims,
             srid,
             dialect,
@@ -83,7 +83,7 @@ impl<'a, W: Write> WktWriter<'a, W> {
     }
 }
 
-impl<W: Write> GeomProcessor for WktWriter<'_, W> {
+impl<W: Write> GeomProcessor for WktWriter<W> {
     fn dimensions(&self) -> CoordDimensions {
         self.dims
     }
@@ -216,9 +216,9 @@ impl<W: Write> GeomProcessor for WktWriter<'_, W> {
     }
 }
 
-impl<W: Write> PropertyProcessor for WktWriter<'_, W> {}
+impl<W: Write> PropertyProcessor for WktWriter<W> {}
 
-impl<W: Write> FeatureProcessor for WktWriter<'_, W> {}
+impl<W: Write> FeatureProcessor for WktWriter<W> {}
 
 #[cfg(test)]
 mod test {

--- a/geozero/src/wkt/wkt_writer.rs
+++ b/geozero/src/wkt/wkt_writer.rs
@@ -65,7 +65,10 @@ impl<W: Write> WktWriter<W> {
         }
         self.geometry_sizes.push(size);
         if size == 0 {
-            self.out.write_all(b" EMPTY")?;
+            if tagged {
+                self.out.write_all(b" ")?;
+            };
+            self.out.write_all(b"EMPTY")?;
         } else {
             self.out.write_all(b"(")?;
         }


### PR DESCRIPTION
Currently, empty geometries would be writter in WKT as:
```
LINESTRING()
POLYGON()
GEOMETRYCOLLECTION()
```
which isn't valid WKT.

This PR addresses this issue and output instead:
```
LINESTRING EMPTY
POLYGON EMPTY
GEOMETRYCOLLECTION EMPTY
```