### PR TITLE
Implement `empty_point` for `GeoJsonWriter`

### DIFF
--- a/geozero/src/geojson/geojson_writer.rs
+++ b/geozero/src/geojson/geojson_writer.rs
@@ -98,6 +98,12 @@ impl<W: Write> GeomProcessor for GeoJsonWriter<'_, W> {
         self.out.write_all(b"]")?;
         Ok(())
     }
+    fn empty_point(&mut self, idx: usize) -> Result<()> {
+        self.comma(idx)?;
+        self.out
+            .write_all(br#"{"type": "Point", "coordinates": []}"#)?;
+        Ok(())
+    }
     fn point_begin(&mut self, idx: usize) -> Result<()> {
         self.comma(idx)?;
         self.out

--- a/geozero/src/geojson/geojson_writer.rs
+++ b/geozero/src/geojson/geojson_writer.rs
@@ -237,6 +237,7 @@ mod test {
     use super::*;
     use crate::geojson::read_geojson;
     use crate::ToJson;
+    use crate::wkt::WktStr;
 
     #[test]
     fn geometries() -> Result<()> {
@@ -426,6 +427,12 @@ mod test {
             &geom.to_json().unwrap(),
             r#"{"type": "Point", "coordinates": [10,20]}"#
         );
+
+        let geom = WktStr("POINT EMPTY");
+        assert_eq!(
+            &geom.to_json().unwrap(),
+            r#"{"type": "Point", "coordinates": []}"#
+        )
     }
 
     fn assert_json_eq(a: &[u8], b: &str) {

--- a/geozero/src/geojson/geojson_writer.rs
+++ b/geozero/src/geojson/geojson_writer.rs
@@ -236,8 +236,8 @@ impl<W: Write> PropertyProcessor for GeoJsonWriter<'_, W> {
 mod test {
     use super::*;
     use crate::geojson::read_geojson;
-    use crate::ToJson;
     use crate::wkt::WktStr;
+    use crate::ToJson;
 
     #[test]
     fn geometries() -> Result<()> {


### PR DESCRIPTION
According to the RFC, empty points may be represented with empty coordinates:
```
RFC 7946


3.1.  Geometry Object

   o  A GeoJSON Geometry object of any type other than "GeometryCollection" has a member with the name "coordinates". The value of the "coordinates" member is an array.  The structure of the elements in this array is determined by the type of geometry.  GeoJSON processors MAY interpret Geometry objects with empty "coordinates" arrays as null objects.
```
This PR therefore implements the GeometryProcessor method `point_empty` for `GeojsonWriter` by writing a point with empty coordinates.
For reference, PostGIS also has this behavior:

```sql
SELECT ST_AsGeoJSON('POINT EMPTY'::geometry);
--> {"type":"Point","coordinates":[]}