### PR TITLE
Compile proto file only when vector_tile.rs doesn't exist

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ postgis = "0.9.0"
 postgres = "0.19"
 postgres-types = "0.2"
 prost = "0.11.9"
+# NOTICE: When updating prost-build, remove geozero/src/mvt/vector_tile.rs to force a rebuild
 prost-build = "0.11.9"
 scroll = "0.11"
 seek_bufread = "1.2"

--- a/geozero/build.rs
+++ b/geozero/build.rs
@@ -24,7 +24,7 @@ fn compile_protos() -> Result<(), Box<dyn std::error::Error>> {
             .write(true)
             .truncate(true)
             .open("src/mvt/vector_tile.rs")?;
-        file.write_all("// This file was automatically generated through the build.rs script, and should not be edited.\n\n".as_bytes())?;
+        file.write_all("// This file was automatically generated through the build.rs script, and should not be edited.\n// Remove this file to force a rebuild.\n\n".as_bytes())?;
         file.write_all(buffer.as_bytes())?;
     }
 

--- a/geozero/build.rs
+++ b/geozero/build.rs
@@ -11,13 +11,7 @@ fn compile_protos() -> Result<(), Box<dyn std::error::Error>> {
     // override the build location, in order to check in the changes to proto files
     env::set_var("OUT_DIR", "src/mvt");
 
-    // The current working directory can vary depending on how the project is being
-    // built or released so we build an absolute path to the proto file
-    let path = Path::new("src/mvt/vector_tile.proto");
-    if path.exists() && cfg!(feature = "with-mvt") && env::var("DOCS_RS").is_err() {
-        // avoid rerunning build if the file has not changed
-        println!("cargo:rerun-if-changed=src/mvt/vector_tile.proto");
-
+    if !Path::new("src/mvt/vector_tile.rs").exists() {
         prost_build::compile_protos(&["src/mvt/vector_tile.proto"], &["src/mvt/"])?;
         // read file contents to string
         let mut file = OpenOptions::new()

--- a/geozero/src/mvt/mvt_reader.rs
+++ b/geozero/src/mvt/mvt_reader.rs
@@ -38,8 +38,7 @@ fn process_properties(
     processor.properties_begin()?;
     for (i, pair) in feature.tags.chunks(2).enumerate() {
         let [key_idx, value_idx] = pair else {
-            return Err(MvtError::InvalidFeatureTagsLength(
-                feature.tags.len()))?
+            return Err(MvtError::InvalidFeatureTagsLength(feature.tags.len()))?;
         };
         let key = layer
             .keys

--- a/geozero/src/mvt/vector_tile.rs
+++ b/geozero/src/mvt/vector_tile.rs
@@ -1,4 +1,5 @@
 // This file was automatically generated through the build.rs script, and should not be edited.
+// Remove this file to force a rebuild.
 
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]


### PR DESCRIPTION
So protoc is not required when used as a dependency.