### PR TITLE
change `Wkb` to non-owning

### DIFF
--- a/geozero/src/wkb/wkb_reader.rs
+++ b/geozero/src/wkb/wkb_reader.rs
@@ -11,11 +11,11 @@ use crate::postgis::diesel::sql_types::{Geography, Geometry};
 use diesel::{deserialize::FromSqlRow, expression::AsExpression};
 
 /// WKB reader.
-pub struct Wkb(pub Vec<u8>);
+pub struct Wkb<B: AsRef<[u8]>>(pub B);
 
-impl GeozeroGeometry for Wkb {
+impl<B: AsRef<[u8]>> GeozeroGeometry for Wkb<B> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> Result<()> {
-        process_wkb_geom(&mut self.0.as_slice(), processor)
+        process_wkb_geom(&mut self.0.as_ref(), processor)
     }
 }
 


### PR DESCRIPTION
I was doing some perf testing on Wkb parsing and this is slightly faster when you already have something else owning bytes. I did some perf benchmarking in geoarrow, and it looks like this is almost 4% faster when you don't need to make the copy, see https://github.com/kylebarron/geoarrow-rs/pull/186

before:
```
parse WKBArray to Vec<geo::Geometry>
                        time:   [39.945 ms 39.977 ms 40.009 ms]
                        change: [-0.4809% -0.3544% -0.2385%] (p = 0.00 < 0.05)
                        Change within noise threshold.
```

after:
```
parse WKBArray to Vec<geo::Geometry>
                        time:   [38.343 ms 38.508 ms 38.686 ms]
                        change: [-4.0973% -3.6748% -3.2766%] (p = 0.00 < 0.05)
                        Performance has improved.
```

I guess this is technically not a breaking change? Because `Vec<u8>` also implements `AsRef<[u8]>`?