### PR TITLE
geozero-cli: HTTP FGB can write to any output

### DIFF
--- a/geozero-cli/src/main.rs
+++ b/geozero-cli/src/main.rs
@@ -55,82 +55,73 @@ fn parse_extent(src: &str) -> std::result::Result<Extent, ParseFloatError> {
     })
 }
 
-fn transform<P: FeatureProcessor>(args: Cli, processor: &mut P) -> Result<()> {
+async fn transform<P: FeatureProcessor>(args: Cli, processor: &mut P) -> Result<()> {
     let path_in = Path::new(&args.input);
-    let mut filein = BufReader::new(File::open(path_in)?);
-    match path_in.extension().and_then(OsStr::to_str) {
-        Some("csv") => {
-            let geometry_column_name = args
-                .csv_geometry_column
-                .expect("must specify --csv-geometry-column=<column name> when parsing CSV");
-            let mut ds = CsvReader::new(&geometry_column_name, &mut filein);
-            GeozeroDatasource::process(&mut ds, processor)
+    if path_in.starts_with("http:") || path_in.starts_with("https:") {
+        if path_in.extension().and_then(OsStr::to_str) != Some("fgb") {
+            panic!("Remote acccess is only supported for .fgb input")
         }
-        Some("json") | Some("geojson") => {
-            GeozeroDatasource::process(&mut GeoJsonReader(filein), processor)
+        let ds = HttpFgbReader::open(&args.input).await?;
+        let mut ds = if let Some(bbox) = &args.extent {
+            ds.select_bbox(bbox.minx, bbox.miny, bbox.maxx, bbox.maxy)
+                .await?
+        } else {
+            ds.select_all().await?
+        };
+        ds.process_features(processor).await
+    } else {
+        let mut filein = BufReader::new(File::open(path_in)?);
+        match path_in.extension().and_then(OsStr::to_str) {
+            Some("csv") => {
+                let geometry_column_name = args
+                    .csv_geometry_column
+                    .expect("must specify --csv-geometry-column=<column name> when parsing CSV");
+                let mut ds = CsvReader::new(&geometry_column_name, &mut filein);
+                GeozeroDatasource::process(&mut ds, processor)
+            }
+            Some("json") | Some("geojson") => {
+                GeozeroDatasource::process(&mut GeoJsonReader(filein), processor)
+            }
+            Some("jsonl") | Some("geojsonl") => {
+                GeozeroDatasource::process(&mut GeoJsonLineReader::new(filein), processor)
+            }
+            Some("fgb") => {
+                let ds = FgbReader::open(&mut filein)?;
+                let mut ds = if let Some(bbox) = &args.extent {
+                    ds.select_bbox(bbox.minx, bbox.miny, bbox.maxx, bbox.maxy)?
+                } else {
+                    ds.select_all()?
+                };
+                ds.process_features(processor)
+            }
+            Some("wkt") => GeozeroDatasource::process(&mut WktReader(&mut filein), processor),
+            _ => panic!("Unknown input file extension"),
         }
-        Some("jsonl") | Some("geojsonl") => {
-            GeozeroDatasource::process(&mut GeoJsonLineReader::new(filein), processor)
-        }
-        Some("fgb") => {
-            let ds = FgbReader::open(&mut filein)?;
-            let mut ds = if let Some(bbox) = &args.extent {
-                ds.select_bbox(bbox.minx, bbox.miny, bbox.maxx, bbox.maxy)?
-            } else {
-                ds.select_all()?
-            };
-            ds.process_features(processor)
-        }
-        Some("wkt") => GeozeroDatasource::process(&mut WktReader(&mut filein), processor),
-        _ => panic!("Unknown input file extension"),
     }
 }
 
-fn process(args: Cli) -> Result<()> {
+async fn process(args: Cli) -> Result<()> {
     let mut fout = BufWriter::new(File::create(&args.dest)?);
     match args.dest.extension().and_then(OsStr::to_str) {
-        Some("csv") => transform(args, &mut CsvWriter::new(&mut fout)),
-        Some("wkt") => transform(args, &mut WktWriter::new(&mut fout)),
-        Some("json") | Some("geojson") => transform(args, &mut GeoJsonWriter::new(&mut fout)),
+        Some("csv") => transform(args, &mut CsvWriter::new(&mut fout)).await?,
+        Some("wkt") => transform(args, &mut WktWriter::new(&mut fout)).await?,
+        Some("json") | Some("geojson") => {
+            transform(args, &mut GeoJsonWriter::new(&mut fout)).await?
+        }
         Some("fgb") => {
             let mut fgb = FgbWriter::create("fgb", GeometryType::Unknown)?;
-            transform(args, &mut fgb)?;
-            fgb.write(&mut fout)
+            transform(args, &mut fgb).await?;
+            fgb.write(&mut fout)?;
         }
         Some("svg") => {
             let mut processor = SvgWriter::new(&mut fout, true);
             set_dimensions(&mut processor, args.extent);
-            transform(args, &mut processor)
+            transform(args, &mut processor).await?;
         }
         _ => panic!("Unknown output file extension"),
     }
+    Ok(())
 }
-
-#[tokio::main]
-async fn process_url(args: Cli) -> Result<()> {
-    let ds = HttpFgbReader::open(&args.input).await?;
-    let mut ds = if let Some(bbox) = &args.extent {
-        ds.select_bbox(bbox.minx, bbox.miny, bbox.maxx, bbox.maxy)
-            .await?
-    } else {
-        ds.select_all().await?
-    };
-
-    let mut fout = BufWriter::new(File::create(&args.dest)?);
-    match args.dest.extension().and_then(OsStr::to_str) {
-        Some("json") | Some("geojson") => {
-            let mut processor = GeoJsonWriter::new(&mut fout);
-            ds.process_features(&mut processor).await
-        }
-        Some("svg") => {
-            let mut processor = SvgWriter::new(&mut fout, true);
-            set_dimensions(&mut processor, args.extent);
-            ds.process_features(&mut processor).await
-        }
-        _ => panic!("Unknown output format"),
-    }
-}
-
 fn set_dimensions(processor: &mut SvgWriter<&mut BufWriter<File>>, extent: Option<Extent>) {
     if let Some(extent) = extent {
         processor.set_dimensions(extent.minx, extent.miny, extent.maxx, extent.maxy, 800, 600);
@@ -140,17 +131,15 @@ fn set_dimensions(processor: &mut SvgWriter<&mut BufWriter<File>>, extent: Optio
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let env = env_logger::Env::default().filter_or(env_logger::DEFAULT_FILTER_ENV, "info");
     env_logger::Builder::from_env(env).init();
 
     let args = Cli::parse();
 
-    let result = if args.input.starts_with("http") {
-        process_url(args)
-    } else {
-        process(args)
-    };
+    let result = process(args).await;
+
     if let Err(msg) = result {
         println!("Processing failed: {msg}");
         exit(1)


### PR DESCRIPTION
Previously only SVG and json outputs were allowed.

There was a separate code path for handling http input, and we (myself included) failed to keep that code path updated as new output formats were added. This PR combines the code paths.