### PR TITLE
address latest clippy lints (from rust-1.73)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -69,9 +69,3 @@ jobs:
         env:
           DATABASE_URL: "${{ steps.pg.outputs.connection-uri }}?sslmode=disable"
 
-      - name: Ensure valid cfg usage
-        shell: bash
-        run: |
-          rustup toolchain install nightly
-          export RUSTFLAGS='-D warnings'
-          cargo +nightly check -Z unstable-options -Z check-cfg --workspace --all-features

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,4 +74,4 @@ jobs:
         run: |
           rustup toolchain install nightly
           export RUSTFLAGS='-D warnings'
-          cargo +nightly check -Z unstable-options -Z check-cfg=features,names,values,output --workspace --all-features
+          cargo +nightly check -Z unstable-options -Z check-cfg --workspace --all-features

--- a/geozero/src/mvt/mvt_reader.rs
+++ b/geozero/src/mvt/mvt_reader.rs
@@ -38,7 +38,7 @@ fn process_properties(
     processor.properties_begin()?;
     for (i, pair) in feature.tags.chunks(2).enumerate() {
         let [key_idx, value_idx] = pair else {
-            return Err(MvtError::InvalidFeatureTagsLength(feature.tags.len()))?;
+            return Err(MvtError::InvalidFeatureTagsLength(feature.tags.len()).into());
         };
         let key = layer
             .keys
@@ -64,7 +64,7 @@ fn process_properties(
         } else if let Some(v) = value.bool_value {
             processor.property(i, key, &ColumnValue::Bool(v))?;
         } else {
-            return Err(MvtError::UnsupportedKeyValueType(key.to_string()))?;
+            return Err(MvtError::UnsupportedKeyValueType(key.to_string()).into());
         }
     }
     processor.properties_end()
@@ -153,11 +153,11 @@ fn process_linestring<P: GeomProcessor>(
     processor: &mut P,
 ) -> Result<()> {
     if geom[0] != CommandInteger::from(Command::MoveTo, 1) {
-        return Err(MvtError::GeometryFormat)?;
+        return Err(MvtError::GeometryFormat.into());
     }
     let lineto = CommandInteger(geom[3]);
     if lineto.id() != Command::LineTo as u32 {
-        return Err(MvtError::GeometryFormat)?;
+        return Err(MvtError::GeometryFormat.into());
     }
     processor.linestring_begin(tagged, 1 + lineto.count() as usize, idx)?;
     process_coord(cursor, &geom[1..3], 0, processor)?;
@@ -206,14 +206,14 @@ fn process_polygon<P: GeomProcessor>(
 
     for (i, ring) in rings.iter().enumerate() {
         if ring[0] != CommandInteger::from(Command::MoveTo, 1) {
-            return Err(MvtError::GeometryFormat)?;
+            return Err(MvtError::GeometryFormat.into());
         }
         if *ring.last().unwrap() != CommandInteger::from(Command::ClosePath, 1) {
-            return Err(MvtError::GeometryFormat)?;
+            return Err(MvtError::GeometryFormat.into());
         }
         let lineto = CommandInteger(ring[3]);
         if lineto.id() != Command::LineTo as u32 {
-            return Err(MvtError::GeometryFormat)?;
+            return Err(MvtError::GeometryFormat.into());
         }
         processor.linestring_begin(false, 1 + lineto.count() as usize, i)?;
         let mut start_cursor = *cursor;
@@ -258,7 +258,7 @@ fn process_polygons<P: GeomProcessor>(
             // add interior ring to previous polygon
             last_slice.push(slice);
         } else {
-            return Err(MvtError::GeometryFormat)?;
+            return Err(MvtError::GeometryFormat.into());
         }
         geom = rest;
     }


### PR DESCRIPTION
Fixes lint failures like this:

```
warning: unneeded `return` statement with `?` operator
   --> geozero/src/mvt/mvt_reader.rs:261:13
    |
261 |             return Err(MvtError::GeometryFormat)?;
    |             ^^^^^^^ help: remove it
```
