### PR TITLE
update flatgeobuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ dbase = "0.4"
 diesel = { version = "2.1.0", default-features = false, features = ["postgres"] }
 dup-indexer = "0.3"
 env_logger = "0.10.0"
-flatgeobuf = "3.27.0"
+flatgeobuf = "4.0.0"
 futures-util = "0.3.28"
 gdal = { version = "0.16", default-features = false }
 gdal-sys = "0.9"

--- a/geozero-bench/benches/geobench.rs
+++ b/geozero-bench/benches/geobench.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use geozero::error::Result;
 use geozero::ToGeo;
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Extent {

--- a/geozero-cli/src/main.rs
+++ b/geozero-cli/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use flatgeobuf::{FgbReader, FgbWriter, GeometryType, HttpFgbReader};
 use geozero::csv::{CsvReader, CsvWriter};
-use geozero::error::Result;
+use geozero::error::{GeozeroError, Result};
 use geozero::geojson::{GeoJsonLineReader, GeoJsonReader, GeoJsonWriter};
 use geozero::svg::SvgWriter;
 use geozero::wkt::{WktReader, WktWriter};
@@ -61,12 +61,15 @@ async fn transform<P: FeatureProcessor>(args: Cli, processor: &mut P) -> Result<
         if path_in.extension().and_then(OsStr::to_str) != Some("fgb") {
             panic!("Remote acccess is only supported for .fgb input")
         }
-        let ds = HttpFgbReader::open(&args.input).await?;
+        let ds = HttpFgbReader::open(&args.input)
+            .await
+            .map_err(fgb_to_geozero_err)?;
         let mut ds = if let Some(bbox) = &args.extent {
             ds.select_bbox(bbox.minx, bbox.miny, bbox.maxx, bbox.maxy)
-                .await?
+                .await
+                .map_err(fgb_to_geozero_err)?
         } else {
-            ds.select_all().await?
+            ds.select_all().await.map_err(fgb_to_geozero_err)?
         };
         ds.process_features(processor).await
     } else {
@@ -86,11 +89,12 @@ async fn transform<P: FeatureProcessor>(args: Cli, processor: &mut P) -> Result<
                 GeozeroDatasource::process(&mut GeoJsonLineReader::new(filein), processor)
             }
             Some("fgb") => {
-                let ds = FgbReader::open(&mut filein)?;
+                let ds = FgbReader::open(&mut filein).map_err(fgb_to_geozero_err)?;
                 let mut ds = if let Some(bbox) = &args.extent {
-                    ds.select_bbox(bbox.minx, bbox.miny, bbox.maxx, bbox.maxy)?
+                    ds.select_bbox(bbox.minx, bbox.miny, bbox.maxx, bbox.maxy)
+                        .map_err(fgb_to_geozero_err)?
                 } else {
-                    ds.select_all()?
+                    ds.select_all().map_err(fgb_to_geozero_err)?
                 };
                 ds.process_features(processor)
             }
@@ -109,9 +113,10 @@ async fn process(args: Cli) -> Result<()> {
             transform(args, &mut GeoJsonWriter::new(&mut fout)).await?
         }
         Some("fgb") => {
-            let mut fgb = FgbWriter::create("fgb", GeometryType::Unknown)?;
+            let mut fgb =
+                FgbWriter::create("fgb", GeometryType::Unknown).map_err(fgb_to_geozero_err)?;
             transform(args, &mut fgb).await?;
-            fgb.write(&mut fout)?;
+            fgb.write(&mut fout).map_err(fgb_to_geozero_err)?;
         }
         Some("svg") => {
             let mut processor = SvgWriter::new(&mut fout, true);
@@ -128,6 +133,25 @@ fn set_dimensions(processor: &mut SvgWriter<&mut BufWriter<File>>, extent: Optio
     } else {
         // TODO: get image size as opts and full extent from data
         processor.set_dimensions(-180.0, -90.0, 180.0, 90.0, 800, 600);
+    }
+}
+
+fn fgb_to_geozero_err(fgb_err: flatgeobuf::Error) -> GeozeroError {
+    match fgb_err {
+        flatgeobuf::Error::MissingMagicBytes => {
+            GeozeroError::Dataset("Malformed FGB - missing Magic Bytes".to_string())
+        }
+        flatgeobuf::Error::NoIndex => GeozeroError::Dataset(
+            "No Index: Index operations are not supported for this FGB".to_string(),
+        ),
+        flatgeobuf::Error::HttpClient(e) => GeozeroError::HttpError(e.to_string()),
+        flatgeobuf::Error::IllegalHeaderSize(size) => {
+            GeozeroError::Dataset(format!("Malformed FGB - Illegal header size: {size}"))
+        }
+        flatgeobuf::Error::InvalidFlatbuffer(e) => {
+            GeozeroError::Dataset(format!("Invalid Flatbuffer: {e}"))
+        }
+        flatgeobuf::Error::IO(io) => GeozeroError::IoError(io),
     }
 }
 

--- a/geozero/tests/geojson.rs
+++ b/geozero/tests/geojson.rs
@@ -1,10 +1,10 @@
 use flatgeobuf::{FgbReader, HttpFgbReader};
-use geozero::error::Result;
 use geozero::geojson::GeoJsonWriter;
 use geozero::ProcessToJson;
 use seek_bufread::BufReader;
 use std::fs::File;
 use std::io::BufWriter;
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[test]
 fn fgb_to_geojson() -> Result<()> {

--- a/geozero/tests/geozero-api.rs
+++ b/geozero/tests/geozero-api.rs
@@ -1,13 +1,15 @@
 use flatgeobuf::{FallibleStreamingIterator as _, FeatureProperties as _, FgbReader, GeometryType};
-use geozero::error::Result;
+use geozero::error::Result as GeozeroResult;
 use geozero::{ColumnValue, CoordDimensions, GeomProcessor, PropertyProcessor};
 use seek_bufread::BufReader;
 use std::fs::File;
 
 struct VertexCounter(u64);
 
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
 impl GeomProcessor for VertexCounter {
-    fn xy(&mut self, _x: f64, _y: f64, _idx: usize) -> Result<()> {
+    fn xy(&mut self, _x: f64, _y: f64, _idx: usize) -> GeozeroResult<()> {
         self.0 += 1;
         Ok(())
     }
@@ -47,7 +49,7 @@ impl GeomProcessor for MaxHeightFinder {
         _t: Option<f64>,
         _tm: Option<u64>,
         _idx: usize,
-    ) -> Result<()> {
+    ) -> GeozeroResult<()> {
         if let Some(z) = z {
             if z > self.0 {
                 self.0 = z
@@ -77,7 +79,7 @@ fn max_height_finder() -> Result<()> {
 struct FeatureFinder;
 
 impl PropertyProcessor for FeatureFinder {
-    fn property(&mut self, i: usize, _name: &str, v: &ColumnValue) -> Result<bool> {
+    fn property(&mut self, i: usize, _name: &str, v: &ColumnValue) -> GeozeroResult<bool> {
         Ok(i == 0 && v == &ColumnValue::String("DNK"))
     }
 }

--- a/geozero/tests/polylabel.rs
+++ b/geozero/tests/polylabel.rs
@@ -1,12 +1,12 @@
 use flatgeobuf::{FallibleStreamingIterator, FeatureProperties, FgbReader};
 use geo::contains::Contains;
 use geo::Geometry;
-use geozero::error::Result;
 use geozero::ToGeo;
 use polylabel::polylabel;
 use seek_bufread::BufReader;
 use std::fs::File;
 
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 #[test]
 fn country_labels() -> Result<()> {
     let mut file = BufReader::new(File::open("tests/data/countries.fgb")?);

--- a/geozero/tests/svg.rs
+++ b/geozero/tests/svg.rs
@@ -1,11 +1,11 @@
 use flatgeobuf::{FgbReader, Header};
-use geozero::error::Result;
 use geozero::geojson::GeoJsonReader;
 use geozero::svg::SvgWriter;
 use geozero::ProcessToSvg;
 use seek_bufread::BufReader;
 use std::fs::File;
 use std::io::Write;
+type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 #[test]
 fn json_to_svg() -> Result<()> {


### PR DESCRIPTION
## Flatgeobuf release notes 4.0.0

https://github.com/flatgeobuf/flatgeobuf/blob/master/src/rust/CHANGELOG.md#400---2023-10-14

> [4.0.0] - 2023-10-14
> 
> Breaking: select_all and select_bbox now return a FeatureIter instead of a modified Self type.
> Ensure reading from tls is supported.
> Breaking: Added flatgeobuf::Error with more specific errors and use it where possible rather than geozero::GeozeroError.
> Added feature batching for HTTP client to optimize remote reading.