### PR TITLE
Fix clippy: remove superfluous use statements

### DIFF
--- a/geozero-shp/src/lib.rs
+++ b/geozero-shp/src/lib.rs
@@ -6,7 +6,6 @@ mod shp_reader;
 mod shx_reader;
 
 pub use crate::header::ShapeType;
-pub use crate::property_processor::*;
 pub use crate::reader::Reader;
 pub use crate::shp_reader::NO_DATA;
 

--- a/geozero/src/gpkg/mod.rs
+++ b/geozero/src/gpkg/mod.rs
@@ -28,5 +28,3 @@
 //! ```
 
 mod geopackage;
-
-pub use geopackage::*;

--- a/geozero/src/postgis/mod.rs
+++ b/geozero/src/postgis/mod.rs
@@ -44,10 +44,7 @@ mod postgis_sqlx;
 /// # Ok(())
 /// # }
 ///```
-#[cfg(feature = "with-postgis-postgres")]
-pub mod postgres {
-    pub use super::postgis_postgres::*;
-}
+pub mod postgres {}
 
 /// PostGIS geometry type encoding/decoding for SQLx.
 ///
@@ -89,9 +86,7 @@ pub mod postgres {
 /// # }
 /// ```
 #[cfg(feature = "with-postgis-sqlx")]
-pub mod sqlx {
-    pub use super::postgis_sqlx::*;
-}
+pub mod sqlx {}
 
 /// Postgis geometry type encoding for Diesel.
 ///


### PR DESCRIPTION
These modules only contain trait implementations and already-exported macros, which don't need to be `use`'d
