### PR TITLE
Configure for merge queue

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,6 +1,6 @@
 name: CI-Linux
 
-on: [push, pull_request]
+on: [push, pull_request, merge_group]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Currently we rely on maintainers to manually verify that CI has passed and that branches are up to date with main.

I'd like to enable GH merge queue (like we have in georust/geo, georust/proj, and a few others). This entails enabling branch protection for main.

All together, these changes will ensure that a PR won't merge until it is confirmed to pass tests when up-to-date with main.