### PR TITLE
Omit GeoJSON properties with null values

### DIFF
--- a/geozero/src/geojson/geojson_reader.rs
+++ b/geozero/src/geojson/geojson_reader.rs
@@ -217,7 +217,9 @@ pub(crate) fn process_properties<P: PropertyProcessor>(
                 processor.property(i, key, &ColumnValue::ULong(v.as_u64().unwrap()))?
             }
             JsonValue::Bool(v) => processor.property(i, key, &ColumnValue::Bool(*v))?,
-            // Null, Array(Vec<Value>), Object(Map<String, Value>)
+            // For null values omit the property
+            JsonValue::Null => false,
+            // Array(Vec<Value>), Object(Map<String, Value>)
             _ => processor.property(i, key, &ColumnValue::String(&value.to_string()))?,
         };
     }

--- a/geozero/tests/postgis.rs
+++ b/geozero/tests/postgis.rs
@@ -239,7 +239,7 @@ mod postgis_sqlx {
         let pool = pg::get_pool().await;
 
         let geom: geo_types::Geometry<f64> = geo::Point::new(10.0, 20.0).into();
-        let geoms = vec![wkb::Encode(geom.clone()), wkb::Encode(geom.clone())];
+        let geoms = [wkb::Encode(geom.clone()), wkb::Encode(geom.clone())];
         let inserted = sqlx::query(
             "INSERT INTO point2d (datetimefield, geom)
                SELECT now(), ST_SetSRID(g,4326) FROM UNNEST($1::geometry[]) as g",


### PR DESCRIPTION
In https://github.com/geoarrow/geoarrow-rs/issues/588 I got a bug report about a [GeoJSON file](https://opendata.arcgis.com/api/v3/datasets/bf5c5110b1b944d299bb683cdbd02d2a_0/downloads/data?format=geojson&spatialRefId=4326&where=1%3D1) that failed to read. The issue here is a column that's numeric for the first N rows but then is `null` for some row `N + 1`. Currently the GeoJSON reader coerces a `null` value to the string `"null"`:
https://github.com/georust/geozero/blob/3378dda305ec88cabb092d458f8a61a140f60827/geozero/src/geojson/geojson_reader.rs#L220-L221

This is hard to work with because in my processor I'd have to check _every_ input string value (from any geozero reader, for any column) against the string "null" and manage type conversions. E.g. if the first few rows of a column are the string `"null"` but then I see an f64 value, I need to be able to coerce that column to a Float64Array (which in Arrow has its own null bitmask).

I'd argue that the simplest approach in this specific case is to do a no-op for GeoJSON null values. That `{"a": 1, "b": null}` is equivalent to `{"a": 1}`. That seems like a much smaller change than, say, adding a `ColumnValue::Null` variant. But interested to hear others' thoughts.