### PR TITLE
Ewkt support srid=0

### DIFF
--- a/geozero/src/wkt/wkt_writer.rs
+++ b/geozero/src/wkt/wkt_writer.rs
@@ -45,7 +45,7 @@ impl<W: Write> WktWriter<W> {
         if self.first_header && self.dialect == WktDialect::Ewkt {
             self.first_header = false;
             match srid {
-                None | Some(0) => (),
+                None => (),
                 Some(srid) => self.out.write_all(format!("SRID={srid};").as_bytes())?,
             }
         }


### PR DESCRIPTION
I think it's nessary  to support srid=0 with ewkt format.
SRID of 0 doesn't technically exist, it just means no SRID or maintain format consistency

See [also](https://docs.snowflake.com/en/sql-reference/functions/st_aswkb) 