### PR TITLE
make `with-gdal` feature require `gdal-sys`

### DIFF
--- a/geozero/Cargo.toml
+++ b/geozero/Cargo.toml
@@ -14,7 +14,7 @@ license.workspace = true
 [features]
 default = ["with-svg", "with-wkt", "with-geo", "with-geojson"]
 with-csv = ["dep:csv", "with-wkt"]
-with-gdal = ["dep:gdal"]
+with-gdal = ["dep:gdal", "dep:gdal-sys"]
 with-gdal-bindgen = ["with-gdal", "gdal?/bindgen"]
 with-geo = ["dep:geo-types"]
 with-geojson = ["dep:geojson"]


### PR DESCRIPTION
`gdal-sys` is its own optional dependency, and currently `with-gdal` does not require it. That means that any import of `gdal-sys` from geozero will fail without the user turning on an explicit `gdal-sys` feature, see #211. So e.g. this fails:

https://github.com/georust/geozero/blob/8f3d8e4b9363aee0d50356936f5be65f496b9953/geozero/src/gdal/gdal_error.rs#L2

I don't see why `with-gdal` wouldn't turn on `gdal-sys`.

Closes https://github.com/georust/geozero/issues/211