### PR TITLE
Avoid copying string for WKT parsing

### DIFF
--- a/geozero/src/wkt/wkt_reader.rs
+++ b/geozero/src/wkt/wkt_reader.rs
@@ -2,6 +2,7 @@ use crate::error::{GeozeroError, Result};
 use crate::{FeatureProcessor, GeomProcessor, GeozeroDatasource, GeozeroGeometry};
 
 use std::io::Read;
+use std::str::FromStr;
 use wkt::types::{Coord, LineString, Polygon};
 use wkt::Geometry;
 
@@ -11,7 +12,10 @@ pub struct Wkt<B: AsRef<[u8]>>(pub B);
 
 impl<B: AsRef<[u8]>> GeozeroGeometry for Wkt<B> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> Result<()> {
-        read_wkt(&mut self.0.as_ref(), processor)
+        let wkt_str = std::str::from_utf8(self.0.as_ref())
+            .map_err(|e| GeozeroError::Geometry(e.to_string()))?;
+        let wkt = wkt::Wkt::from_str(wkt_str).map_err(|e| GeozeroError::Geometry(e.to_string()))?;
+        process_wkt_geom(&wkt.item, processor)
     }
 }
 
@@ -24,7 +28,9 @@ pub struct WktString(pub String);
 impl GeozeroGeometry for WktString {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> Result<()> {
         #[allow(deprecated)]
-        read_wkt(&mut self.0.as_bytes(), processor)
+        let wkt = wkt::Wkt::from_str(self.0.as_str())
+            .map_err(|e| GeozeroError::Geometry(e.to_string()))?;
+        process_wkt_geom(&wkt.item, processor)
     }
 }
 
@@ -36,7 +42,8 @@ pub struct WktStr<'a>(pub &'a str);
 impl GeozeroGeometry for WktStr<'_> {
     fn process_geom<P: GeomProcessor>(&self, processor: &mut P) -> Result<()> {
         #[allow(deprecated)]
-        read_wkt(&mut self.0.as_bytes(), processor)
+        let wkt = wkt::Wkt::from_str(self.0).map_err(|e| GeozeroError::Geometry(e.to_string()))?;
+        process_wkt_geom(&wkt.item, processor)
     }
 }
 
@@ -44,7 +51,8 @@ impl GeozeroGeometry for WktStr<'_> {
 impl GeozeroDatasource for WktStr<'_> {
     fn process<P: FeatureProcessor>(&mut self, processor: &mut P) -> Result<()> {
         #[allow(deprecated)]
-        read_wkt(&mut self.0.as_bytes(), processor)
+        let wkt = wkt::Wkt::from_str(self.0).map_err(|e| GeozeroError::Geometry(e.to_string()))?;
+        process_wkt_geom(&wkt.item, processor)
     }
 }
 
@@ -72,7 +80,6 @@ impl<R: Read> GeozeroDatasource for WktReader<R> {
 
 /// Read and process WKT geometry.
 pub fn read_wkt<R: Read, P: GeomProcessor>(reader: &mut R, processor: &mut P) -> Result<()> {
-    use std::str::FromStr;
     // PERF: it would be good to avoid copying data into this string when we already
     // have a string as input. Maybe the wkt crate needs a from_reader implementation.
     let mut wkt_string = String::new();


### PR DESCRIPTION
Currently bytes are converted into a `Read` and then collected _back_ into a string. It would be preferable to pass `[u8]` or `str` directly into `wkt::Wkt::from_str`