### PR TITLE
Remove this test - it's tripping up CI and redundant anyway.

### DIFF
--- a/geozero/tests/postgis.rs
+++ b/geozero/tests/postgis.rs
@@ -255,7 +255,7 @@ mod postgis_sqlx {
     #[tokio::test]
     #[ignore]
     // Requires DATABASE_URL at compile time
-    #[cfg(feature = "dont-compile")]
+    #[cfg(not(test))] // Delete this line to compile the test
     async fn rust_geo_macro_query() -> Result<(), sqlx::Error> {
         let pool = pg::get_pool().await;
 


### PR DESCRIPTION
Clippy CI explodes because we're using a non-existent feature. It fails
to compile without DATABASE_URL

```
error: unexpected `cfg` condition value: `dont-compile`
   --> geozero/tests/postgis.rs:258:11
    |
258 |     #[cfg(feature = "dont-compile")]
    |           ^^^^^^^^^^^^^^^^^^^^^^^^
```

But what is this test testing anyway? We already have tests inserting
geo-points into sqlx (see rust_geo_query), so my understanding is that
the thing this test covers is that the sqlx macro behaves the same way,
as the programmatic API, which I'd argue is sqlx's job, not ours.
