### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ clap = { version = "4.3", features = ["derive"] }
 criterion = "0.5.1"
 csv = "1.2.2"
 dbase = "0.4"
-diesel = { version = "2.1.0", default-features = false, features = ["postgres"] }
+diesel = { version = "2.2.3", default-features = false, features = ["postgres"] }
 dup-indexer = "0.3"
 env_logger = "0.10.0"
 futures-util = "0.3.28"


### PR DESCRIPTION
Bumps the dependency to at least 2.2.3 as per the advisory

[Advisory](https://rustsec.org/advisories/RUSTSEC-2024-0365.html)

(even though this crate may not be using the function mentioned in the advisory, it is better to bump it to ensure that there is no chance of other dependencies pulling it)