### PR TITLE
CLI adds bounds calculation and style flag to csv writer

### DIFF
--- a/geozero-cli/src/main.rs
+++ b/geozero-cli/src/main.rs
@@ -29,6 +29,10 @@ struct Cli {
 
     /// The path to the file to write
     dest: PathBuf,
+
+    /// Will be placed within <style>...</style> tags of the top level svg element.
+    #[arg(long)]
+    svg_style: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -123,6 +127,7 @@ async fn process(args: Cli) -> Result<()> {
             let extent = get_extent(&args).await?;
             let mut processor = SvgWriter::new(&mut fout, true);
             // TODO: get width/height from args
+            processor.set_style(args.svg_style.clone());
             processor.set_dimensions(extent.minx, extent.miny, extent.maxx, extent.maxy, 800, 600);
             transform(&args, &mut processor).await?;
         }

--- a/geozero-cli/src/main.rs
+++ b/geozero-cli/src/main.rs
@@ -55,7 +55,7 @@ fn parse_extent(src: &str) -> std::result::Result<Extent, ParseFloatError> {
     })
 }
 
-async fn transform<P: FeatureProcessor>(args: Cli, processor: &mut P) -> Result<()> {
+async fn transform<P: FeatureProcessor>(args: &Cli, processor: &mut P) -> Result<()> {
     let path_in = Path::new(&args.input);
     if path_in.starts_with("http:") || path_in.starts_with("https:") {
         if path_in.extension().and_then(OsStr::to_str) != Some("fgb") {
@@ -78,8 +78,9 @@ async fn transform<P: FeatureProcessor>(args: Cli, processor: &mut P) -> Result<
             Some("csv") => {
                 let geometry_column_name = args
                     .csv_geometry_column
+                    .as_ref()
                     .expect("must specify --csv-geometry-column=<column name> when parsing CSV");
-                let mut ds = CsvReader::new(&geometry_column_name, &mut filein);
+                let mut ds = CsvReader::new(geometry_column_name, &mut filein);
                 GeozeroDatasource::process(&mut ds, processor)
             }
             Some("json") | Some("geojson") => {
@@ -107,32 +108,51 @@ async fn transform<P: FeatureProcessor>(args: Cli, processor: &mut P) -> Result<
 async fn process(args: Cli) -> Result<()> {
     let mut fout = BufWriter::new(File::create(&args.dest)?);
     match args.dest.extension().and_then(OsStr::to_str) {
-        Some("csv") => transform(args, &mut CsvWriter::new(&mut fout)).await?,
-        Some("wkt") => transform(args, &mut WktWriter::new(&mut fout)).await?,
+        Some("csv") => transform(&args, &mut CsvWriter::new(&mut fout)).await?,
+        Some("wkt") => transform(&args, &mut WktWriter::new(&mut fout)).await?,
         Some("json") | Some("geojson") => {
-            transform(args, &mut GeoJsonWriter::new(&mut fout)).await?
+            transform(&args, &mut GeoJsonWriter::new(&mut fout)).await?
         }
         Some("fgb") => {
             let mut fgb =
                 FgbWriter::create("fgb", GeometryType::Unknown).map_err(fgb_to_geozero_err)?;
-            transform(args, &mut fgb).await?;
+            transform(&args, &mut fgb).await?;
             fgb.write(&mut fout).map_err(fgb_to_geozero_err)?;
         }
         Some("svg") => {
+            let extent = get_extent(&args).await?;
             let mut processor = SvgWriter::new(&mut fout, true);
-            set_dimensions(&mut processor, args.extent);
-            transform(args, &mut processor).await?;
+            // TODO: get width/height from args
+            processor.set_dimensions(extent.minx, extent.miny, extent.maxx, extent.maxy, 800, 600);
+            transform(&args, &mut processor).await?;
         }
         _ => panic!("Unknown output file extension"),
     }
     Ok(())
 }
-fn set_dimensions(processor: &mut SvgWriter<&mut BufWriter<File>>, extent: Option<Extent>) {
-    if let Some(extent) = extent {
-        processor.set_dimensions(extent.minx, extent.miny, extent.maxx, extent.maxy, 800, 600);
-    } else {
-        // TODO: get image size as opts and full extent from data
-        processor.set_dimensions(-180.0, -90.0, 180.0, 90.0, 800, 600);
+
+async fn get_extent(args: &Cli) -> Result<Extent> {
+    match args.extent {
+        Some(extent) => Ok(extent),
+        None => {
+            let mut bounds_processor = geozero::bounds::BoundsProcessor::new();
+            transform(args, &mut bounds_processor).await?;
+            let Some(computed_bounds) = bounds_processor.bounds() else {
+                return Ok(Extent {
+                    minx: 0.0,
+                    miny: 0.0,
+                    maxx: 0.0,
+                    maxy: 0.0,
+                });
+            };
+
+            Ok(Extent {
+                minx: computed_bounds.min_x(),
+                miny: computed_bounds.min_y(),
+                maxx: computed_bounds.max_x(),
+                maxy: computed_bounds.max_y(),
+            })
+        }
     }
 }
 

--- a/geozero/CHANGELOG.md
+++ b/geozero/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## UNRELEASED
 
+* Add `style` option to SVGWriter for writing \<style\> tags
 * Add `BoundsProcessor` to compute bounds of geometry
 * Update Deps:
   * BREAKING: `flatgeobuf` to 4.5.0


### PR DESCRIPTION
Adds the ability to specify a top level `<style>` block in your svg output. 

Also exposes this functionality (and the recent bound computation #250) to the CLI's svg output.

It's very basic. So basic that I'm not sure it's worth it, but I'm personally using it so I thought I'd see if it had wider appeal.