### PR TITLE
chore: upgrade geos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,4 +56,4 @@ tokio = { version = "1.30.0", default-features = false }
 wkt = "0.12.0"
 
 [patch.crates-io]
-#geozero = { path = "./geozero" }
+geozero = { path = "./geozero" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ gdal-sys = "0.10.0"
 geo = "0.29.3"
 geo-types = { version = "0.7.11", default-features = false }
 geojson = { version = "0.24.1", default-features = false }
-geos = "9.0"
+geos = "10.0"
 gpx = { version = "0.9", default-features = false }
 hex = "0.4"
 kdbush = "0.2"


### PR DESCRIPTION
`geos@9` is yanked. Can you update a new version to crates.io?