### PR TITLE
mvt: expose Command, CommandInteger, ParameterInteger from the module

### DIFF
--- a/geozero/src/mvt/mod.rs
+++ b/geozero/src/mvt/mod.rs
@@ -1,5 +1,6 @@
 //! MVT conversions.
 mod mvt_commands;
+pub use mvt_commands::{Command, CommandInteger, ParameterInteger};
 pub(crate) mod mvt_reader;
 pub(crate) mod mvt_writer;
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

This PR exposes `mvt::mvt_commands::{Command, CommandInteger, ParameterInteger` as a part of the `mvt` module.

I'm currently working on [a PR to generate MVTs from GeoJSON files for the Martin tile server](https://github.com/maplibre/martin/pull/2098). Since writing features (geom + properties) to MVTs is not supported by `geozero` yet, it could be useful to expose `mvt_commands::{Command, CommandInteger, ParameterInteger` such that users can implement the functionality on their own.

cc: @nyurik 

