### PR TITLE
chore(ci): split the linting and testing CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -86,18 +86,18 @@ jobs:
         env:
           DATABASE_URL: "${{ steps.pg.outputs.connection-uri }}?sslmode=disable"
           
-    # This final step is needed to mark the whole workflow as successful
-    # Don't change its name - it is used by the merge protection rules
-    done:
-      name: stable - x86_64-unknown-linux-gnu
-      runs-on: ubuntu-latest
-      needs: [ lint, test ]
-      if: always()
-      permissions: {}
-      steps:
-        - name: Result of the needed steps
-          run: echo "${{ toJSON(needs) }}"
-        - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
-          name: CI Result
-          run: exit 1
+  # This final step is needed to mark the whole workflow as successful
+  # Don't change its name - it is used by the merge protection rules
+  done:
+    name: stable - x86_64-unknown-linux-gnu
+    runs-on: ubuntu-latest
+    needs: [ lint, test ]
+    if: always()
+    permissions: {}
+    steps:
+      - name: Result of the needed steps
+        run: echo "${{ toJSON(needs) }}"
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        name: CI Result
+        run: exit 1
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

CI is by all standards relatively slow (6m) compared to what it does.
This is because we are doing all checks in one thread on the same worker.

We don't need to => this PR moves all linting tasks into its own job => reducing the total CI time by ~2m.