### PR TITLE
fix(ci): audit check action checking ts by mistake

### DIFF
--- a/.github/workflows/audit-check.yml
+++ b/.github/workflows/audit-check.yml
@@ -39,7 +39,6 @@ jobs:
       matrix:
         include:
         - language: actions
-        - language: javascript-typescript
         - language: rust
     steps:
     - name: Checkout repository


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

remove the misguided ts security action