### PR TITLE
ci: add non-blocking Codecov coverage upload job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,43 @@ jobs:
           cargo test -p geozero --all-features -- --ignored postgis --test-threads 1
         env:
           DATABASE_URL: "${{ steps.pg.outputs.connection-uri }}?sslmode=disable"
+
+  coverage:
+    name: coverage - stable - x86_64-unknown-linux-gnu
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          rustc --version
+          cargo --version
+          sudo apt-get update
+          sudo apt-get install -y libgdal-dev libgeos-dev
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
+
+      - name: Install cargo-llvm-cov
+        shell: bash
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Generate coverage report
+        shell: bash
+        run: |
+          mkdir -p target/llvm-cov
+          cargo llvm-cov --workspace --all-targets --all-features --include-build-script --codecov --output-path target/llvm-cov/codecov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: target/llvm-cov/codecov.info
+          fail_ci_if_error: false
           
   # This final step is needed to mark the whole workflow as successful
   # Don't change its name - it is used by the merge protection rules

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
           cargo llvm-cov --workspace --all-targets --all-features --include-build-script --codecov --output-path target/llvm-cov/codecov.info
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5.5.5
         with:
           files: target/llvm-cov/codecov.info
           fail_ci_if_error: false


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
I added a coverage job to CI that generates llvm-cov output and uploads it to Codecov without enforcing a coverage threshold.
For this I introduced a dedicated coverage step in the Linux workflow, enabled continue-on-error behavior, and configured Codecov upload to not fail CI on upload issues.

This results in that we get immediate coverage visibility and trend tracking with zero merge friction, which is a low-risk first step before any future gating policy.