### PR TITLE
test(postgis): replace ignored tests with env-based skip

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -82,7 +82,7 @@ jobs:
         shell: bash
         run: |
           psql -P pager=off -v ON_ERROR_STOP=1 -f geozero/tests/data/postgis.sql $DATABASE_URL
-          cargo test -p geozero --all-features -- --ignored postgis --test-threads 1
+          cargo test -p geozero --all-features --test postgis -- --test-threads 1
         env:
           DATABASE_URL: "${{ steps.pg.outputs.connection-uri }}?sslmode=disable"
           

--- a/README.md
+++ b/README.md
@@ -266,3 +266,19 @@ Full source code: [kdbush.rs](./geozero/tests/kdbush.rs)
 # Ubuntu/Debian/Mint
 apt-get install -y libgeos-dev libgdal-dev
 ```
+
+## Testing
+
+PostGIS integration tests in `geozero/tests/postgis.rs` run automatically when `DATABASE_URL` is set.
+If `DATABASE_URL` is not set, those tests are skipped with an informational message.
+
+Examples:
+
+```sh
+# regular test run (PostGIS tests auto-skip when DATABASE_URL is unset)
+cargo test -p geozero --all-features
+
+# run PostGIS tests explicitly
+DATABASE_URL=postgres://ci:ci@localhost:5432/test?sslmode=disable \
+    cargo test -p geozero --all-features --test postgis -- --test-threads 1
+```

--- a/geozero/tests/postgis.rs
+++ b/geozero/tests/postgis.rs
@@ -1,4 +1,13 @@
 mod pg {
+    pub fn should_skip_postgis_tests() -> bool {
+        if std::env::var("DATABASE_URL").is_ok() {
+            false
+        } else {
+            eprintln!("Skipping PostGIS tests: DATABASE_URL is not set");
+            true
+        }
+    }
+
     pub fn get_db_string() -> String {
         std::env::var("DATABASE_URL").unwrap()
     }
@@ -21,8 +30,10 @@ mod postgis_postgres {
     use geozero::wkt::WktWriter;
 
     #[test]
-    #[ignore]
     fn blob_query() -> Result<(), postgres::error::Error> {
+        if crate::pg::should_skip_postgis_tests() {
+            return Ok(());
+        }
         let mut client = postgres::Client::connect(&get_db_string(), postgres::NoTls).unwrap();
         let row = client.query_one(
             "SELECT 'SRID=4326;POLYGON ((0 0, 2 0, 2 2, 0 2, 0 0))'::geometry::bytea",
@@ -36,8 +47,10 @@ mod postgis_postgres {
     }
 
     #[test]
-    #[ignore]
     fn rust_geo_query() -> Result<(), postgres::error::Error> {
+        if crate::pg::should_skip_postgis_tests() {
+            return Ok(());
+        }
         let mut client = postgres::Client::connect(&get_db_string(), postgres::NoTls).unwrap();
 
         let row = client.query_one(
@@ -73,9 +86,11 @@ mod postgis_postgres {
     }
 
     #[test]
-    #[ignore]
     #[cfg(feature = "with-geos")]
     fn geos_query() -> Result<(), postgres::error::Error> {
+        if crate::pg::should_skip_postgis_tests() {
+            return Ok(());
+        }
         let mut client = postgres::Client::connect(&get_db_string(), postgres::NoTls).unwrap();
 
         let row = client.query_one(
@@ -124,8 +139,10 @@ mod postgis_postgres {
         }
 
         #[test]
-        #[ignore]
         fn geometry_query() -> Result<(), postgres::error::Error> {
+            if crate::pg::should_skip_postgis_tests() {
+                return Ok(());
+            }
             let mut client = postgres::Client::connect(&get_db_string(), postgres::NoTls).unwrap();
 
             let row = client.query_one(
@@ -148,8 +165,10 @@ mod postgis_sqlx {
     use geozero::wkb;
 
     #[tokio::test]
-    #[ignore]
     async fn blob_query() -> Result<(), sqlx::Error> {
+        if pg::should_skip_postgis_tests() {
+            return Ok(());
+        }
         let pool = pg::get_pool().await;
 
         let row: (Vec<u8>,) = sqlx::query_as(
@@ -173,8 +192,10 @@ mod postgis_sqlx {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn point3d_query() -> Result<(), sqlx::Error> {
+        if pg::should_skip_postgis_tests() {
+            return Ok(());
+        }
         let pool = pg::get_pool().await;
 
         let row: (PointZ,) = sqlx::query_as("SELECT 'POINT(1 2 3)'::geometry")
@@ -195,8 +216,10 @@ mod postgis_sqlx {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn rust_geo_query() -> Result<(), sqlx::Error> {
+        if pg::should_skip_postgis_tests() {
+            return Ok(());
+        }
         let pool = pg::get_pool().await;
 
         let row: (wkb::Decode<geo_types::Geometry<f64>>,) =
@@ -233,8 +256,10 @@ mod postgis_sqlx {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn bulk_insert() -> Result<(), sqlx::Error> {
+        if pg::should_skip_postgis_tests() {
+            return Ok(());
+        }
         // https://github.com/launchbadge/sqlx/blob/v0.5.13/FAQ.md#how-can-i-bind-an-array-to-a-values-clause-how-can-i-do-bulk-inserts
         let pool = pg::get_pool().await;
 
@@ -253,7 +278,6 @@ mod postgis_sqlx {
     }
 
     #[tokio::test]
-    #[ignore]
     // Requires DATABASE_URL at compile time
     #[cfg(not(test))] // Delete this line to compile the test
     async fn rust_geo_macro_query() -> Result<(), sqlx::Error> {
@@ -310,9 +334,11 @@ mod postgis_sqlx {
     }
 
     #[tokio::test]
-    #[ignore]
     #[cfg(feature = "with-geos")]
     async fn geos_query() -> Result<(), sqlx::Error> {
+        if pg::should_skip_postgis_tests() {
+            return Ok(());
+        }
         let pool = pg::get_pool().await;
 
         let row: (wkb::Decode<geos::Geometry>,) =
@@ -376,8 +402,10 @@ mod postgis_sqlx {
         }
 
         #[tokio::test]
-        #[ignore]
         async fn geometry_query() -> Result<(), sqlx::Error> {
+            if pg::should_skip_postgis_tests() {
+                return Ok(());
+            }
             let pool = pg::get_pool().await;
 
             let row: (Text,) =


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [ ] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
I removed blanket ignore usage for PostGIS integration tests and switched to environment-aware execution.
This is done by adding a shared runtime skip helper that skips only when DATABASE_URL is missing, updated CI to run the PostGIS test target directly, and documented the behavior in the README.
I changed this to keeps local developer workflows smooth while making CI behavior explicit and deterministic, improving test maintainability and reducing hidden test coverage gaps.