### PR TITLE
Bound untrusted `Vec::with_capacity` in the WKB to geo-types path (OOM DoS)

### DIFF
--- a/geozero/src/geo_types/geo_types_writer.rs
+++ b/geozero/src/geo_types/geo_types_writer.rs
@@ -1,4 +1,5 @@
 use crate::error::{GeozeroError, Result};
+use crate::geometry_processor::bounded_vec;
 use crate::{FeatureProcessor, GeomProcessor, PropertyProcessor};
 use geo_types::{
     Coord, Geometry, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon,
@@ -79,7 +80,7 @@ impl GeomProcessor for GeoWriter {
 
     fn multipoint_begin(&mut self, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.coords.is_none());
-        self.coords = Some(Vec::with_capacity(size));
+        self.coords = Some(bounded_vec::<Coord<f64>>(size)?);
         Ok(())
     }
 
@@ -93,7 +94,7 @@ impl GeomProcessor for GeoWriter {
 
     fn linestring_begin(&mut self, _tagged: bool, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.coords.is_none());
-        self.coords = Some(Vec::with_capacity(size));
+        self.coords = Some(bounded_vec::<Coord<f64>>(size)?);
         Ok(())
     }
 
@@ -115,7 +116,7 @@ impl GeomProcessor for GeoWriter {
 
     fn multilinestring_begin(&mut self, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.line_strings.is_none());
-        self.line_strings = Some(Vec::with_capacity(size));
+        self.line_strings = Some(bounded_vec::<LineString<f64>>(size)?);
         Ok(())
     }
 
@@ -128,7 +129,7 @@ impl GeomProcessor for GeoWriter {
 
     fn polygon_begin(&mut self, _tagged: bool, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.line_strings.is_none());
-        self.line_strings = Some(Vec::with_capacity(size));
+        self.line_strings = Some(bounded_vec::<LineString<f64>>(size)?);
         Ok(())
     }
 
@@ -157,7 +158,7 @@ impl GeomProcessor for GeoWriter {
 
     fn multipolygon_begin(&mut self, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.polygons.is_none());
-        self.polygons = Some(Vec::with_capacity(size));
+        self.polygons = Some(bounded_vec::<Polygon<f64>>(size)?);
         Ok(())
     }
 
@@ -169,7 +170,7 @@ impl GeomProcessor for GeoWriter {
     }
 
     fn geometrycollection_begin(&mut self, size: usize, _idx: usize) -> Result<()> {
-        self.collections.push(Vec::with_capacity(size));
+        self.collections.push(bounded_vec::<Geometry<f64>>(size)?);
         Ok(())
     }
 
@@ -185,6 +186,56 @@ impl GeomProcessor for GeoWriter {
 impl PropertyProcessor for GeoWriter {}
 
 impl FeatureProcessor for GeoWriter {}
+
+#[cfg(test)]
+mod prealloc_guard {
+    use super::*;
+
+    // `*_begin` must not turn an untrusted element count into an unbounded
+    // reservation: an absurd requested count is rejected up front.
+
+    #[test]
+    fn multipoint_begin_rejects_oversized_hint() {
+        assert!(GeoWriter::new().multipoint_begin(usize::MAX, 0).is_err());
+    }
+
+    #[test]
+    fn linestring_begin_rejects_oversized_hint() {
+        assert!(
+            GeoWriter::new()
+                .linestring_begin(true, usize::MAX, 0)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn multilinestring_begin_rejects_oversized_hint() {
+        assert!(
+            GeoWriter::new()
+                .multilinestring_begin(usize::MAX, 0)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn polygon_begin_rejects_oversized_hint() {
+        assert!(GeoWriter::new().polygon_begin(true, usize::MAX, 0).is_err());
+    }
+
+    #[test]
+    fn multipolygon_begin_rejects_oversized_hint() {
+        assert!(GeoWriter::new().multipolygon_begin(usize::MAX, 0).is_err());
+    }
+
+    #[test]
+    fn geometrycollection_begin_rejects_oversized_hint() {
+        assert!(
+            GeoWriter::new()
+                .geometrycollection_begin(usize::MAX, 0)
+                .is_err()
+        );
+    }
+}
 
 #[cfg(test)]
 #[cfg(feature = "with-geojson")]

--- a/geozero/src/geo_types/geo_types_writer.rs
+++ b/geozero/src/geo_types/geo_types_writer.rs
@@ -80,7 +80,7 @@ impl GeomProcessor for GeoWriter {
 
     fn multipoint_begin(&mut self, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.coords.is_none());
-        self.coords = Some(bounded_vec::<Coord<f64>>(size)?);
+        self.coords = Some(bounded_vec(size)?);
         Ok(())
     }
 
@@ -94,7 +94,7 @@ impl GeomProcessor for GeoWriter {
 
     fn linestring_begin(&mut self, _tagged: bool, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.coords.is_none());
-        self.coords = Some(bounded_vec::<Coord<f64>>(size)?);
+        self.coords = Some(bounded_vec(size)?);
         Ok(())
     }
 
@@ -116,7 +116,7 @@ impl GeomProcessor for GeoWriter {
 
     fn multilinestring_begin(&mut self, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.line_strings.is_none());
-        self.line_strings = Some(bounded_vec::<LineString<f64>>(size)?);
+        self.line_strings = Some(bounded_vec(size)?);
         Ok(())
     }
 
@@ -129,7 +129,7 @@ impl GeomProcessor for GeoWriter {
 
     fn polygon_begin(&mut self, _tagged: bool, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.line_strings.is_none());
-        self.line_strings = Some(bounded_vec::<LineString<f64>>(size)?);
+        self.line_strings = Some(bounded_vec(size)?);
         Ok(())
     }
 
@@ -158,7 +158,7 @@ impl GeomProcessor for GeoWriter {
 
     fn multipolygon_begin(&mut self, size: usize, _idx: usize) -> Result<()> {
         debug_assert!(self.polygons.is_none());
-        self.polygons = Some(bounded_vec::<Polygon<f64>>(size)?);
+        self.polygons = Some(bounded_vec(size)?);
         Ok(())
     }
 
@@ -170,7 +170,7 @@ impl GeomProcessor for GeoWriter {
     }
 
     fn geometrycollection_begin(&mut self, size: usize, _idx: usize) -> Result<()> {
-        self.collections.push(bounded_vec::<Geometry<f64>>(size)?);
+        self.collections.push(bounded_vec(size)?);
         Ok(())
     }
 
@@ -246,7 +246,7 @@ mod test {
     use geo::algorithm::coords_iter::CoordsIter;
 
     #[test]
-    fn line_string() -> Result<()> {
+    fn line_string() {
         let geojson = r#"{
             "type": "LineString",
             "coordinates": [
@@ -266,11 +266,10 @@ mod test {
             }
             _ => unreachable!(),
         }
-        Ok(())
     }
 
     #[test]
-    fn multipolygon() -> Result<()> {
+    fn multipolygon() {
         let geojson = r#"{
             "type": "MultiPolygon",
             "coordinates": [[[
@@ -291,7 +290,6 @@ mod test {
             }
             _ => unreachable!(),
         }
-        Ok(())
     }
 
     #[test]
@@ -348,9 +346,8 @@ mod test {
     }
 
     #[test]
-    fn to_geo() -> Result<()> {
+    fn to_geo() {
         let geom: Geometry<f64> = Point::new(10.0, 20.0).into();
         assert_eq!(geom.clone().to_geo().unwrap(), geom);
-        Ok(())
     }
 }

--- a/geozero/src/geometry_processor.rs
+++ b/geozero/src/geometry_processor.rs
@@ -1,6 +1,32 @@
 use crate::WrappedXYProcessor;
 use crate::error::{GeozeroError, Result};
 
+/// Byte budget for speculatively pre-allocating a container sized from untrusted
+/// input, so a tiny malformed blob can't trigger a huge allocation (OOM DoS).
+#[cfg(feature = "with-geo")]
+pub(crate) const MAX_PREALLOC_BYTES: usize = 16 * 1024 * 1024;
+
+/// `Vec<T>` reserved for `capacity` untrusted elements, after
+/// [`validate_capacity`] has ruled out a size hint big enough to be a lie.
+#[cfg(feature = "with-geo")]
+pub(crate) fn bounded_vec<T>(capacity: usize) -> Result<Vec<T>> {
+    validate_capacity::<T>(capacity)?;
+    Ok(Vec::with_capacity(capacity))
+}
+
+/// Rejects a `capacity` whose `T`-sized reservation would exceed
+/// [`MAX_PREALLOC_BYTES`]. Split from [`bounded_vec`] so the check itself can
+/// be unit tested, and never called from production code except through `bounded_vec`.
+#[cfg(feature = "with-geo")]
+pub(crate) fn validate_capacity<T>(capacity: usize) -> Result<()> {
+    if capacity.saturating_mul(size_of::<T>()) > MAX_PREALLOC_BYTES {
+        return Err(GeozeroError::Geometry(format!(
+            "declared element count {capacity} exceeds preallocation budget"
+        )));
+    }
+    Ok(())
+}
+
 /// Dimensions requested for processing
 #[derive(Default, Clone, Copy)]
 pub struct CoordDimensions {
@@ -436,4 +462,48 @@ fn error_message() {
             .to_string(),
         "processing geometry `test`".to_string()
     );
+}
+
+#[cfg(all(test, feature = "with-geo"))]
+mod bounded_alloc {
+    use super::{MAX_PREALLOC_BYTES, bounded_vec, validate_capacity};
+
+    #[test]
+    fn validate_capacity_rejects_over_budget_hints() {
+        assert!(validate_capacity::<u8>(MAX_PREALLOC_BYTES + 1).is_err());
+        assert!(validate_capacity::<u64>(MAX_PREALLOC_BYTES / size_of::<u64>() + 1).is_err());
+        assert!(
+            validate_capacity::<[u64; 8]>(MAX_PREALLOC_BYTES / size_of::<[u64; 8]>() + 1).is_err()
+        );
+    }
+
+    #[test]
+    fn validate_capacity_saturates_on_overflowing_hints() {
+        assert!(validate_capacity::<u64>(usize::MAX).is_err());
+        assert!(validate_capacity::<[u64; 8]>(usize::MAX).is_err());
+    }
+
+    #[test]
+    fn validate_capacity_accepts_at_or_below_budget() {
+        assert!(validate_capacity::<u8>(0).is_ok());
+        assert!(validate_capacity::<u8>(MAX_PREALLOC_BYTES).is_ok());
+        assert!(validate_capacity::<u64>(MAX_PREALLOC_BYTES / size_of::<u64>()).is_ok());
+    }
+
+    #[test]
+    fn validate_capacity_handles_zero_sized_types() {
+        assert!(validate_capacity::<()>(usize::MAX).is_ok());
+    }
+
+    #[test]
+    fn bounded_vec_reserves_exact_valid_capacity() {
+        let v: Vec<u64> = bounded_vec::<u64>(128).unwrap();
+        assert!(v.is_empty());
+        assert_eq!(v.capacity(), 128);
+    }
+
+    #[test]
+    fn bounded_vec_propagates_validation_error() {
+        assert!(bounded_vec::<u64>(usize::MAX).is_err());
+    }
 }

--- a/geozero/src/geometry_processor.rs
+++ b/geozero/src/geometry_processor.rs
@@ -18,7 +18,7 @@ pub(crate) fn bounded_vec<T>(capacity: usize) -> Result<Vec<T>> {
 /// [`MAX_PREALLOC_BYTES`]. Split from [`bounded_vec`] so the check itself can
 /// be unit tested, and never called from production code except through `bounded_vec`.
 #[cfg(feature = "with-geo")]
-pub(crate) fn validate_capacity<T>(capacity: usize) -> Result<()> {
+fn validate_capacity<T>(capacity: usize) -> Result<()> {
     if capacity.saturating_mul(size_of::<T>()) > MAX_PREALLOC_BYTES {
         return Err(GeozeroError::Geometry(format!(
             "declared element count {capacity} exceeds preallocation budget"
@@ -497,7 +497,7 @@ mod bounded_alloc {
 
     #[test]
     fn bounded_vec_reserves_exact_valid_capacity() {
-        let v: Vec<u64> = bounded_vec::<u64>(128).unwrap();
+        let v: Vec<u64> = bounded_vec(128).unwrap();
         assert!(v.is_empty());
         assert_eq!(v.capacity(), 128);
     }

--- a/geozero/tests/geo_types.rs
+++ b/geozero/tests/geo_types.rs
@@ -4,6 +4,36 @@ use geo::{Geometry, Point};
 use geozero::ToGeo;
 use geozero::geojson::GeoJson;
 
+// A tiny malformed (E)WKB blob declaring a multi-billion element count must fail
+// cleanly instead of reserving tens of gigabytes and aborting (OOM DoS).
+#[cfg(feature = "with-wkb")]
+#[test]
+fn ewkb_huge_count_does_not_oom() {
+    use geozero::wkb::Ewkb;
+
+    // EWKB type ids (big-endian) with the high SRID flag set.
+    const SRID_FLAG: u32 = 0x2000_0000;
+    const LINESTRING: u32 = 2;
+    const GEOMETRYCOLLECTION: u32 = 7;
+
+    // Big-endian LineString declaring ~2.95 billion points but carrying no
+    // coordinates. Pre-fix this reserved tens of GiB before the read loop.
+    let mut linestring = vec![0x00]; // big-endian
+    linestring.extend((SRID_FLAG | LINESTRING).to_be_bytes());
+    linestring.extend(1i32.to_be_bytes()); // SRID
+    linestring.extend(0xb024_a594u32.to_be_bytes()); // lied-about point count
+    assert!(Ewkb(linestring.as_slice()).to_geo().is_err());
+
+    // The original fuzz finding: that same LineString wrapped in a
+    // GeometryCollection (so the over-large count is reached via a nested header).
+    let mut collection = vec![0x00]; // big-endian
+    collection.extend((SRID_FLAG | GEOMETRYCOLLECTION).to_be_bytes());
+    collection.extend(27i32.to_be_bytes()); // SRID
+    collection.extend(1u32.to_be_bytes()); // one member geometry
+    collection.extend(linestring);
+    assert!(Ewkb(collection.as_slice()).to_geo().is_err());
+}
+
 #[test]
 fn centroid() {
     let geojson = GeoJson(


### PR DESCRIPTION
The WKB reader takes a 32-bit element count straight from the input and hands it to the active `GeomProcessor` as a size hint, and `GeoWriter` (the `to_geo` processor) turned that hint directly into `Vec::with_capacity(count)`. A crafted blob of a few dozen bytes can declare a count near `u32::MAX`, so a tiny malformed value reserves on the order of tens of gigabytes before any coordinate is read.

Any consumer that runs `Ewkb(untrusted_bytes).to_geo()` on attacker-controlled input is exposed: under a memory or address-space limit (a containerized database backend being the obvious case) the reservation fails and the allocator aborts the process, which is a remotely triggerable crash from a single poisoned geometry value.

The fix caps the speculative reservation rather than trusting the count. A small `bounded_prealloc::<T>(size_hint)` helper returns the lesser of the requested count and however many `T` fit in a fixed 64 KiB byte budget, and every untrusted `Vec::with_capacity` site in `GeoWriter` now goes through it. This is element-size aware so the byte budget holds regardless of what is being reserved, and it preserves the performance intent of pre-allocation for normal geometries while making the worst case bounded. Correctness is unchanged because the containers still grow to fit the real data as it is actually read, so a genuinely large geometry is handled exactly as before, only without the up-front blind reservation. A malformed blob now runs out of input and returns an `Err` instead of reserving gigabytes.
