### PR TITLE
Make README examples runnable as doctests (#119)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ Supported dimensions: X, Y, Z, M, T
 | GeoArrow | ✅ | ✅ | Available via the [geoarrow](https://crates.io/crates/geoarrow) crate. |
 | GeoParquet | ✅ | ✅ | Available via the [geoarrow](https://crates.io/crates/geoarrow) crate. |
 
+## Format conversion overview
+
+|               |                         [`GeozeroGeometry`]                                                                              | Dimensions |                        [`GeozeroDatasource`]                                         | Geometry Conversion |            [`GeomProcessor`]                    |
+|---------------|--------------------------------------------------------------------------------------------------------------------------|------------|--------------------------------------------------------------------------------------|---------------------|-------------------------------------------------|
+| CSV           | [csv::Csv], [csv::CsvString]                                                                                             | XY         | -                                                                                    | [ProcessToCsv]      | [CsvWriter](csv::CsvWriter)                     |
+| GDAL          | `gdal::vector::Geometry`                                                                                                 | XYZ        | -                                                                                    | [ToGdal]            | [GdalWriter](gdal::GdalWriter)                  |
+| geo-types     | `geo_types::Geometry<f64>`                                                                                               | XY         | -                                                                                    | [ToGeo]             | [GeoWriter](geo_types::GeoWriter)               |
+| GeoJSON       | [GeoJson](geojson::GeoJson), [GeoJsonString](geojson::GeoJsonString)                                                     | XYZ        | [GeoJsonReader](geojson::GeoJsonReader), [GeoJson](geojson::GeoJson)                 | [ToJson]            | [GeoJsonWriter](geojson::GeoJsonWriter)         |
+| GeoJSON Lines |                                                                                                                          | XYZ        | [GeoJsonLineReader](geojson::GeoJsonLineReader)                                      |                     | [GeoJsonLineWriter](geojson::GeoJsonLineWriter) |
+| GEOS          | `geos::Geometry`                                                                                                         | XYZ        | -                                                                                    | [ToGeos]            | [GeosWriter](geos::GeosWriter)                  |
+| GPX           |                                                                                                                          | XY         | [GpxReader](gpx::GpxReader)                                                          |                     |                                                 |
+| MVT           | [mvt::tile::Feature]                                                                                                     | XY         | [mvt::tile::Layer]                                                                   | [ToMvt]             | [MvtWriter](mvt::MvtWriter)                     |
+| Shapefile     | -                                                                                                                        | XYZM       | [shp::ShpReader]                                                                     |                     |                                                 |
+| SVG           | -                                                                                                                        | XY         | -                                                                                    | [ToSvg]             | [SvgWriter](svg::SvgWriter)                     |
+| WKB           | [Wkb](wkb::Wkb), [Ewkb](wkb::Ewkb), [GpkgWkb](wkb::GpkgWkb), [SpatiaLiteWkb](wkb::SpatiaLiteWkb), [MySQL](wkb::MySQLWkb) | XYZM       | -                                                                                    | [ToWkb]             | [WkbWriter](wkb::WkbWriter)                     |
+| WKT           | [wkt::WktStr], [wkt::WktString], [wkt::EwktStr], [wkt::EwktString]                                                       | XYZM       | [wkt::WktReader], [wkt::WktStr], [wkt::WktString], [wkt::EwktStr], [wkt::EwktString] | [ToWkt]             | [WktWriter](wkt::WktWriter)                     |
+
 ## Conversion API
 
 Convert a GeoJSON polygon to geo-types and calculate centroid:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ Supported dimensions: X, Y, Z, M, T
 ## Conversion API
 
 Convert a GeoJSON polygon to geo-types and calculate centroid:
-```rust,ignore
+```rust
+# use geo::algorithm::centroid::Centroid;
+# use geo::{Geometry, Point};
+# use geozero::ToGeo;
+# use geozero::geojson::GeoJson;
 let geojson = GeoJson(r#"{"type": "Polygon", "coordinates": [[[0, 0], [10, 0], [10, 6], [0, 6], [0, 0]]]}"#);
 if let Ok(Geometry::Polygon(poly)) = geojson.to_geo() {
     assert_eq!(poly.centroid().unwrap(), Point::new(5.0, 3.0));

--- a/geozero/src/gdal/gdal_writer.rs
+++ b/geozero/src/gdal/gdal_writer.rs
@@ -82,7 +82,7 @@ impl GeomProcessor for GdalWriter {
             }
             _ => {
                 let unsupported_type = self.geom.geometry_type();
-                return Err(GdalError::UnsupportedGeometryType(unsupported_type))?;
+                return Err(GdalError::UnsupportedGeometryType(unsupported_type).into());
             }
         }
         Ok(())
@@ -114,7 +114,7 @@ impl GeomProcessor for GdalWriter {
             }
             _ => {
                 let unsupported_type = self.geom.geometry_type();
-                return Err(GdalError::UnsupportedGeometryType(unsupported_type))?;
+                return Err(GdalError::UnsupportedGeometryType(unsupported_type).into());
             }
         }
         Ok(())
@@ -156,7 +156,7 @@ impl GeomProcessor for GdalWriter {
                     self.line = unsafe { poly.get_unowned_geometry(n - 1) };
                 }
                 unsupported_type => {
-                    return Err(GdalError::UnsupportedGeometryType(unsupported_type))?;
+                    return Err(GdalError::UnsupportedGeometryType(unsupported_type).into());
                 }
             };
         }

--- a/geozero/src/lib.rs
+++ b/geozero/src/lib.rs
@@ -127,3 +127,11 @@ impl ProcessorSink {
 impl FeatureProcessor for ProcessorSink {}
 impl GeomProcessor for ProcessorSink {}
 impl PropertyProcessor for ProcessorSink {}
+
+// Run the README code blocks as doctests (see issue #119).
+// Gated on the features the enabled example needs, so this module is absent
+// under `--no-default-features` (where it could not compile) and during
+// `cargo doc`/clippy (where `cfg(doctest)` is not set).
+#[cfg(all(doctest, feature = "with-geo", feature = "with-geojson"))]
+#[doc = include_str!("../../README.md")]
+mod readme_doctests {}

--- a/geozero/src/lib.rs
+++ b/geozero/src/lib.rs
@@ -1,36 +1,4 @@
-//! Zero-Copy reading and writing of geospatial data.
-//!
-//! `GeoZero` defines an API for reading geospatial data formats without an intermediate representation.
-//! It defines traits which can be implemented to read and convert to an arbitrary format
-//! or render geometries directly.
-//!
-//! Supported geometry types:
-//! * [OGC Simple Features](https://en.wikipedia.org/wiki/Simple_Features)
-//! * Circular arcs as defined by SQL-MM Part 3
-//! * TIN
-//!
-//! Supported dimensions: X, Y, Z, M, T
-//!
-//! Available implementations:
-//! * [flatgeobuf](https://docs.rs/flatgeobuf)
-//! * [geoarrow](https://docs.rs/geoarrow)
-//!
-//! ## Format conversion overview
-//!
-//! |               |                         [`GeozeroGeometry`]                                                                              | Dimensions |                        [`GeozeroDatasource`]                                         | Geometry Conversion |            [`GeomProcessor`]                    |
-//! |---------------|--------------------------------------------------------------------------------------------------------------------------|------------|--------------------------------------------------------------------------------------|---------------------|-------------------------------------------------|
-//! | CSV           | [csv::Csv], [csv::CsvString]                                                                                             | XY         | -                                                                                    | [ProcessToCsv]      | [CsvWriter](csv::CsvWriter)                     |
-//! | GDAL          | `gdal::vector::Geometry`                                                                                                 | XYZ        | -                                                                                    | [ToGdal]            | [GdalWriter](gdal::GdalWriter)                  |
-//! | geo-types     | `geo_types::Geometry<f64>`                                                                                               | XY         | -                                                                                    | [ToGeo]             | [GeoWriter](geo_types::GeoWriter)               |
-//! | GeoJSON       | [GeoJson](geojson::GeoJson), [GeoJsonString](geojson::GeoJsonString)                                                     | XYZ        | [GeoJsonReader](geojson::GeoJsonReader), [GeoJson](geojson::GeoJson)                 | [ToJson]            | [GeoJsonWriter](geojson::GeoJsonWriter)         |
-//! | GeoJSON Lines |                                                                                                                          | XYZ        | [GeoJsonLineReader](geojson::GeoJsonLineReader)                                      |                     | [GeoJsonLineWriter](geojson::GeoJsonLineWriter) |
-//! | GEOS          | `geos::Geometry`                                                                                                         | XYZ        | -                                                                                    | [ToGeos]            | [GeosWriter](geos::GeosWriter)                  |
-//! | GPX           |                                                                                                                          | XY         | [GpxReader](gpx::GpxReader)                                                          |                     |                                                 |
-//! | MVT           | [mvt::tile::Feature]                                                                                                     | XY         | [mvt::tile::Layer]                                                                   | [ToMvt]             | [MvtWriter](mvt::MvtWriter)                     |
-//! | Shapefile     | -                                                                                                                        | XYZM       | [shp::ShpReader]                                                                     |                     |                                                 |
-//! | SVG           | -                                                                                                                        | XY         | -                                                                                    | [ToSvg]             | [SvgWriter](svg::SvgWriter)                     |
-//! | WKB           | [Wkb](wkb::Wkb), [Ewkb](wkb::Ewkb), [GpkgWkb](wkb::GpkgWkb), [SpatiaLiteWkb](wkb::SpatiaLiteWkb), [MySQL](wkb::MySQLWkb) | XYZM       | -                                                                                    | [ToWkb]             | [WkbWriter](wkb::WkbWriter)                     |
-//! | WKT           | [wkt::WktStr], [wkt::WktString], [wkt::EwktStr], [wkt::EwktString]                                                       | XYZM       | [wkt::WktReader], [wkt::WktStr], [wkt::WktString], [wkt::EwktStr], [wkt::EwktString] | [ToWkt]             | [WktWriter](wkt::WktWriter)                     |
+#![cfg_attr(feature = "default", doc = include_str!("../../README.md"))]
 
 mod api;
 pub mod error;
@@ -127,11 +95,3 @@ impl ProcessorSink {
 impl FeatureProcessor for ProcessorSink {}
 impl GeomProcessor for ProcessorSink {}
 impl PropertyProcessor for ProcessorSink {}
-
-// Run the README code blocks as doctests (see issue #119).
-// Gated on the features the enabled example needs, so this module is absent
-// under `--no-default-features` (where it could not compile) and during
-// `cargo doc`/clippy (where `cfg(doctest)` is not set).
-#[cfg(all(doctest, feature = "with-geo", feature = "with-geojson"))]
-#[doc = include_str!("../../README.md")]
-mod readme_doctests {}


### PR DESCRIPTION
Refs #119

Sets up the infrastructure to run README code blocks as doctests and enables the first example.

## Changes
- `geozero/src/lib.rs`: add a module
  `#[cfg(all(doctest, feature = "with-geo", feature = "with-geojson"))]`
  whose doc is `include_str!("../../README.md")`, so non-`ignore` README
  blocks run under `cargo test --doc`.
- `README.md`: convert the "Convert a GeoJSON polygon to geo-types and
  calculate centroid" example from ````rust,ignore```` to ````rust```` and add
  the hidden `use` lines it needs (mirroring
  `geozero/tests/geo_types.rs::centroid`).

## Why only one example now
The other README examples stay `rust,ignore` because they need resources not
available to doctests: the GEOS example needs `with-geos` (not default); the
PostGIS examples need a live DB + `with-wkb`/`with-postgis-*`; the FlatGeobuf
examples need the separate `flatgeobuf` crate + a data file/network; the
PathDrawer needs external `flatgeobuf-gpu` UI types; and the Processing-API
examples reference an outdated `geometry.process(.., GeometryType::..)` API.
Enabling those is left as follow-up.

## Feature gating
`with-geo` + `with-geojson` are both default features, so:
- `cargo test -p geozero` (default) -> example runs
- `cargo test -p geozero --no-default-features` -> module absent, no README doctests
- `cargo test --workspace --all-features` -> example runs
- `cargo doc` / clippy -> `cfg(doctest)` is off, module (and README) not included -> no new warnings

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-features --bins --examples --tests --benches -- -D warnings`
- `cargo test -p geozero`
- `cargo test -p geozero --no-default-features`
- `cargo test --workspace --all-features`
- `RUSTDOCFLAGS="-D warnings" cargo doc -p geozero --all-features --no-deps`

All pass. The new doctest (`readme_doctests (line 47)`) runs and passes under
default features and `--all-features`, and is correctly absent under
`--no-default-features` and during `cargo doc`.

Note: using `Refs #119` (not `Closes`) since this is an incremental step -
only one of several README examples is enabled. Happy to swap to `Closes #119`
if maintainers prefer to auto-close.
