### PR TITLE
Bound untrusted Vec reservations in the Shapefile reader (OOM/panic DoS)

### DIFF
--- a/geozero/src/geometry_processor.rs
+++ b/geozero/src/geometry_processor.rs
@@ -3,12 +3,14 @@ use crate::error::{GeozeroError, Result};
 
 /// Byte budget for speculatively pre-allocating a container sized from untrusted
 /// input, so a tiny malformed blob can't trigger a huge allocation (OOM DoS).
-#[cfg(feature = "with-geo")]
+///
+/// Shared by every reader/writer that reserves a `Vec` from a size hint decoded off
+/// untrusted bytes (the WKB→geo-types path, the MVT writer, and the Shapefile reader).
+/// Kept ungated so a reader can use it without pulling in `with-geo`.
 pub(crate) const MAX_PREALLOC_BYTES: usize = 16 * 1024 * 1024;
 
 /// `Vec<T>` reserved for `capacity` untrusted elements, after
 /// [`validate_capacity`] has ruled out a size hint big enough to be a lie.
-#[cfg(feature = "with-geo")]
 pub(crate) fn bounded_vec<T>(capacity: usize) -> Result<Vec<T>> {
     validate_capacity::<T>(capacity)?;
     Ok(Vec::with_capacity(capacity))
@@ -17,7 +19,6 @@ pub(crate) fn bounded_vec<T>(capacity: usize) -> Result<Vec<T>> {
 /// Rejects a `capacity` whose `T`-sized reservation would exceed
 /// [`MAX_PREALLOC_BYTES`]. Split from [`bounded_vec`] so the check itself can
 /// be unit tested, and never called from production code except through `bounded_vec`.
-#[cfg(feature = "with-geo")]
 fn validate_capacity<T>(capacity: usize) -> Result<()> {
     if capacity.saturating_mul(size_of::<T>()) > MAX_PREALLOC_BYTES {
         return Err(GeozeroError::Geometry(format!(
@@ -464,7 +465,7 @@ fn error_message() {
     );
 }
 
-#[cfg(all(test, feature = "with-geo"))]
+#[cfg(test)]
 mod bounded_alloc {
     use super::{MAX_PREALLOC_BYTES, bounded_vec, validate_capacity};
 

--- a/geozero/src/shp/shp_reader.rs
+++ b/geozero/src/shp/shp_reader.rs
@@ -73,7 +73,11 @@ fn read_shape_rec<P: GeomProcessor, T: Read>(
     record_size: usize,
 ) -> Result<(), Error> {
     let shape_type = ShapeType::read_from(&mut source)?;
-    let record_size = record_size - size_of::<i32>();
+    // The shape type is part of the record, so the remaining body is 4 bytes shorter.
+    // A record_size below that underflows (debug panic / release wrap to ~1.8e19).
+    let record_size = record_size
+        .checked_sub(size_of::<i32>())
+        .ok_or(Error::InvalidShapeRecordSize)?;
     match shape_type {
         ShapeType::Point => read_point(processor, &mut source, record_size, shape_type)?,
         ShapeType::PointM => read_point(processor, &mut source, record_size, shape_type)?,

--- a/geozero/src/shp/shp_reader.rs
+++ b/geozero/src/shp/shp_reader.rs
@@ -4,6 +4,7 @@ use std::mem::size_of;
 use byteorder::{BigEndian, LittleEndian, ReadBytesExt};
 
 use crate::GeomProcessor;
+use crate::geometry_processor::bounded_vec;
 use crate::shp::{Error, ShapeType};
 
 /// Value inferior to this are considered as NO_DATA
@@ -33,14 +34,36 @@ impl RecordHeader {
     }
 }
 
+/// Coerce an untrusted `i32` count field (e.g. `num_points`, `num_parts`, or a
+/// `record_size`/`file_length` doubling) into a `usize` that is safe to feed to a
+/// `Vec` reservation.
+///
+/// Rejects negative counts (the ESRI spec describes these as non-negative record
+/// sizes/counts; a negative value sign-extends to ~1.8e19 when cast `as usize`, which
+/// either panics with `capacity overflow` or requests a multi-GB allocation from a
+/// handful of bytes — a tiny-input OOM/panic DoS). Returns [`Error::InvalidShapeRecordSize`]
+/// so the record is skipped instead of crashing the reader.
+pub(crate) fn validate_count(count: i32) -> Result<usize, Error> {
+    if count.is_negative() {
+        return Err(Error::InvalidShapeRecordSize);
+    }
+    Ok(count as usize)
+}
+
 /// Read and process one shape record
 pub(crate) fn read_shape<'a, P: GeomProcessor + 'a, T: Read>(
     processor: &'a mut P,
     mut source: &mut T,
 ) -> Result<RecordHeader, Error> {
     let hdr = RecordHeader::read_from(&mut source)?;
-    let record_size = hdr.record_size * 2;
-    read_shape_rec(processor, &mut source, record_size as usize)?;
+    // `record_size` is in 16-bit words; double it to get bytes. Reject negatives and
+    // guarded-doubling overflow up front so a hostile header can't reach the body
+    // allocation with a wrapped value.
+    let record_size = validate_count(hdr.record_size)?;
+    let record_size = record_size
+        .checked_mul(2)
+        .ok_or(Error::InvalidShapeRecordSize)?;
+    read_shape_rec(processor, &mut source, record_size)?;
     Ok(hdr)
 }
 
@@ -134,18 +157,22 @@ fn read_multipoint<P: GeomProcessor, T: Read>(
     point_type: ShapeType,
 ) -> Result<(), Error> {
     let _bbox = read_bbox(source, 2)?;
-    let num_points = source.read_i32::<LittleEndian>()? as usize;
+    let num_points = validate_count(source.read_i32::<LittleEndian>()?)?;
 
     let mut size = 4 * size_of::<f64>() // BBOX
     + size_of::<i32>() // num points
-    + size_of::<f64>() * 2 * num_points;
+    + size_of::<f64>()
+        .checked_mul(2)
+        .ok_or(Error::InvalidShapeRecordSize)?
+        .checked_mul(num_points)
+        .ok_or(Error::InvalidShapeRecordSize)?;
     let has_z = point_type == ShapeType::PointZ;
     if has_z {
-        size += multipart_dim_value_size(num_points);
+        size += multipart_dim_value_size(num_points)?;
     }
-    let has_m = record_size == size + multipart_dim_value_size(num_points);
+    let has_m = record_size == size + multipart_dim_value_size(num_points)?;
     if has_m {
-        size += multipart_dim_value_size(num_points);
+        size += multipart_dim_value_size(num_points)?;
     }
 
     if record_size != size {
@@ -212,7 +239,7 @@ fn read_multipatch_shape_content<P: GeomProcessor, T: Read>(
     record_size: usize,
 ) -> Result<(), Error> {
     // TODO
-    let mut buffer = vec![0; record_size];
+    let mut buffer = bounded_vec(record_size)?;
     source.read_exact(&mut buffer)?;
     Ok(())
 }
@@ -238,18 +265,24 @@ impl MultiPartShape {
         has_z: bool,
     ) -> Result<MultiPartShape, Error> {
         let _bbox = read_bbox(source, 2)?;
-        let num_parts = source.read_i32::<LittleEndian>()? as usize;
-        let num_points = source.read_i32::<LittleEndian>()? as usize;
-        let mut rec_size = multipart_record_size(num_points, num_parts);
+        let num_parts = validate_count(source.read_i32::<LittleEndian>()?)?;
+        let num_points = validate_count(source.read_i32::<LittleEndian>()?)?;
+        let mut rec_size = multipart_record_size(num_points, num_parts)?;
         if has_z {
-            rec_size += multipart_dim_value_size(num_points);
+            rec_size = rec_size
+                .checked_add(multipart_dim_value_size(num_points)?)
+                .ok_or(Error::InvalidShapeRecordSize)?;
         }
-        let has_m = record_size == rec_size + multipart_dim_value_size(num_points);
+        let has_m = record_size == rec_size + multipart_dim_value_size(num_points)?;
         if record_size != rec_size && !has_m {
             return Err(Error::InvalidShapeRecordSize);
         }
 
-        let mut parts_index = Vec::with_capacity(num_parts + 1);
+        let mut parts_index = bounded_vec(
+            num_parts
+                .checked_add(1)
+                .ok_or(Error::InvalidShapeRecordSize)?,
+        )?;
         for _ in 0..num_parts {
             parts_index.push(source.read_i32::<LittleEndian>()? as usize);
         }
@@ -357,19 +390,28 @@ impl MultiPartShape {
     }
 }
 
-fn multipart_record_size(num_points: usize, num_parts: usize) -> usize {
+fn multipart_record_size(num_points: usize, num_parts: usize) -> Result<usize, Error> {
     let mut size = 0usize;
     size += 4 * size_of::<f64>(); // BBOX
     size += size_of::<i32>(); // num parts
     size += size_of::<i32>(); // num points
-    size += size_of::<i32>() * num_parts;
-    size += size_of::<f64>() * 2 * num_points;
-    size
+    size += size_of::<i32>()
+        .checked_mul(num_parts)
+        .ok_or(Error::InvalidShapeRecordSize)?;
+    size += size_of::<f64>()
+        .checked_mul(2)
+        .ok_or(Error::InvalidShapeRecordSize)?
+        .checked_mul(num_points)
+        .ok_or(Error::InvalidShapeRecordSize)?;
+    Ok(size)
 }
 
-fn multipart_dim_value_size(num_points: usize) -> usize {
-    2 * size_of::<f64>() // range
-     + num_points * size_of::<f64>() // values
+fn multipart_dim_value_size(num_points: usize) -> Result<usize, Error> {
+    let values = size_of::<f64>()
+        .checked_mul(num_points)
+        .ok_or(Error::InvalidShapeRecordSize)?;
+    Ok(2 * size_of::<f64>() // range
+        + values)
 }
 
 fn read_bbox<R: Read>(source: &mut R, dims: usize) -> Result<Vec<f64>, Error> {
@@ -381,7 +423,7 @@ fn read_bbox<R: Read>(source: &mut R, dims: usize) -> Result<Vec<f64>, Error> {
 }
 
 fn read_xy<R: Read>(source: &mut R, num_points: usize) -> Result<Vec<Coord>, Error> {
-    let mut coords = Vec::with_capacity(num_points);
+    let mut coords = bounded_vec(num_points)?;
     for _ in 0..num_points {
         let x = source.read_f64::<LittleEndian>()?;
         let y = source.read_f64::<LittleEndian>()?;
@@ -392,7 +434,7 @@ fn read_xy<R: Read>(source: &mut R, num_points: usize) -> Result<Vec<Coord>, Err
 
 fn read_dim_values<R: Read>(source: &mut R, num_points: usize) -> Result<Vec<f64>, Error> {
     let _range = read_bbox(source, 1)?;
-    let mut values = Vec::with_capacity(num_points);
+    let mut values = bounded_vec(num_points)?;
     for _ in 0..num_points {
         values.push(source.read_f64::<LittleEndian>()?);
     }

--- a/geozero/src/shp/shx_reader.rs
+++ b/geozero/src/shp/shx_reader.rs
@@ -2,6 +2,8 @@ use std::io::Read;
 
 use byteorder::{BigEndian, ReadBytesExt};
 
+use crate::geometry_processor::bounded_vec;
+use crate::shp::shp_reader::validate_count;
 use crate::shp::{Error, header};
 
 const INDEX_RECORD_SIZE: usize = 2 * size_of::<i32>();
@@ -17,8 +19,21 @@ pub(crate) struct ShapeIndex {
 pub(crate) fn read_index_file<T: Read>(mut source: T) -> Result<Vec<ShapeIndex>, Error> {
     let header = header::Header::read_from(&mut source)?;
 
-    let num_shapes = ((header.file_length * 2) - header::HEADER_SIZE) / INDEX_RECORD_SIZE as i32;
-    let mut shapes_index = Vec::<ShapeIndex>::with_capacity(num_shapes as usize);
+    // `file_length` is an untrusted `i32` in 16-bit words. A negative value cast
+    // `as usize` sign-extends to ~1.8e19 and the `Vec` reservation below panics
+    // (`capacity overflow`) or requests a multi-GB allocation from a tiny `.shx`.
+    let file_length = validate_count(header.file_length)?;
+    let file_length_bytes = file_length
+        .checked_mul(2)
+        .ok_or(Error::InvalidShapeRecordSize)?;
+    if file_length_bytes < header::HEADER_SIZE as usize {
+        // A truncated/empty index yields no records rather than an underflowing
+        // (wrapping) shape count.
+        return Ok(Vec::new());
+    }
+    let num_shapes = (file_length_bytes - header::HEADER_SIZE as usize) / INDEX_RECORD_SIZE;
+
+    let mut shapes_index = bounded_vec::<ShapeIndex>(num_shapes)?;
     for _ in 0..num_shapes {
         let offset = source.read_i32::<BigEndian>()?;
         let record_size = source.read_i32::<BigEndian>()?;

--- a/geozero/tests/shp-reader.rs
+++ b/geozero/tests/shp-reader.rs
@@ -406,3 +406,154 @@ fn polygonzm() -> Result<(), geozero::shp::Error> {
 
     Ok(())
 }
+
+// --- untrusted-count preallocation / overflow DoS regression tests ---
+//
+// Mirrors the WKB hardening (#297/#299): every `.shp`/`.shx` count field decoded
+// off untrusted bytes must be validated before being handed to a `Vec` reservation,
+// so a tiny malformed record returns `Err` instead of panicking (`capacity overflow`
+// / debug int-overflow) or requesting a multi-GB allocation.
+
+use std::io::Cursor;
+
+/// Build a valid 100-byte shapefile main header so `ShpReader::new` accepts the
+/// stream; `file_length_words` is the (attacker-controlled) file-length field.
+fn shp_main_header(file_length_words: i32) -> Vec<u8> {
+    let mut h = Vec::with_capacity(100);
+    h.extend_from_slice(&9994i32.to_be_bytes()); // file_code
+    h.extend_from_slice(&[0u8; 20]); // 5x i32 skip
+    h.extend_from_slice(&file_length_words.to_be_bytes()); // file_length (16-bit words), BE
+    h.extend_from_slice(&1000i32.to_le_bytes()); // version, LE
+    h.extend_from_slice(&0i32.to_le_bytes()); // shape_type (NullShape), LE
+    h.extend_from_slice(&[0u8; 64]); // 8x f64 bbox
+    assert_eq!(h.len(), 100);
+    h
+}
+
+/// Drive the public `ShpReader::new(Cursor) -> iter_geometries` path with `bytes`
+/// and collect the first result. Returns `Ok(())` only if the iterator yields an
+/// `Err` (the safe outcome) rather than panicking.
+fn assert_record_errors(name: &str, bytes: Vec<u8>) {
+    let result = std::panic::catch_unwind(|| {
+        let reader = ShpReader::new(Cursor::new(bytes)).expect("header parse");
+        let mut sink = ProcessorSink::new();
+        reader.iter_geometries(&mut sink).next()
+    });
+    match result {
+        Ok(None) => panic!("[{name}] iterator yielded None (no record read)"),
+        Ok(Some(Ok(_))) => panic!("[{name}] record decoded successfully from malformed input"),
+        Ok(Some(Err(_))) => { /* the safe outcome: malformed record rejected */ }
+        Err(payload) => {
+            let msg = payload
+                .downcast_ref::<String>()
+                .map(String::as_str)
+                .or_else(|| payload.downcast_ref::<&'static str>().copied())
+                .unwrap_or("<non-string panic>");
+            panic!("[{name}] PANIC on malformed input (regression): {msg}");
+        }
+    }
+}
+
+#[test]
+fn multipatch_negative_record_size_is_rejected_not_panicked() {
+    // record_size (BE i32) = -1 -> vec![0; ~1.8e19] capacity overflow before the fix.
+    let mut b = shp_main_header(500);
+    b.extend_from_slice(&1i32.to_be_bytes()); // record_number
+    b.extend_from_slice(&(-1i32).to_be_bytes()); // record_size (untrusted) = -1
+    b.extend_from_slice(&31i32.to_le_bytes()); // shape_type = Multipatch
+    assert_record_errors("multipatch record_size=-1", b);
+}
+
+#[test]
+fn multipatch_huge_record_size_is_rejected_not_oom() {
+    // record_size (BE i32) = i32::MAX -> after *2 a multi-GB reservation.
+    let mut b = shp_main_header(500);
+    b.extend_from_slice(&1i32.to_be_bytes());
+    b.extend_from_slice(&i32::MAX.to_be_bytes()); // record_size = i32::MAX (untrusted)
+    b.extend_from_slice(&31i32.to_le_bytes()); // shape_type = Multipatch
+    assert_record_errors("multipatch record_size=MAX", b);
+}
+
+#[test]
+fn polygon_negative_num_points_is_rejected_not_panicked() {
+    // num_points (LE i32) = -1 -> multipart_record_size(16 * -1) debug-mul-overflow /
+    // read_xy Vec::with_capacity(~1.8e19) capacity overflow before the fix.
+    let mut b = shp_main_header(500);
+    b.extend_from_slice(&1i32.to_be_bytes()); // record_number
+    b.extend_from_slice(&1000i32.to_be_bytes()); // record_size (large enough to survive the check)
+    b.extend_from_slice(&5i32.to_le_bytes()); // shape_type = Polygon
+    b.extend_from_slice(&[0u8; 32]); // bbox (4x f64)
+    b.extend_from_slice(&1i32.to_le_bytes()); // num_parts = 1
+    b.extend_from_slice(&(-1i32).to_le_bytes()); // num_points = -1 (untrusted)
+    assert_record_errors("polygon num_points=-1", b);
+}
+
+#[test]
+fn multipoint_negative_num_points_is_rejected_not_panicked() {
+    // Multipoint with num_points (LE i32) = -1.
+    let mut b = shp_main_header(500);
+    b.extend_from_slice(&1i32.to_be_bytes()); // record_number
+    b.extend_from_slice(&1000i32.to_be_bytes()); // record_size
+    b.extend_from_slice(&8i32.to_le_bytes()); // shape_type = Multipoint
+    b.extend_from_slice(&[0u8; 32]); // bbox (4x f64)
+    b.extend_from_slice(&(-1i32).to_le_bytes()); // num_points = -1 (untrusted)
+    assert_record_errors("multipoint num_points=-1", b);
+}
+
+#[test]
+fn polyline_huge_num_parts_is_rejected_not_oom() {
+    // num_parts (LE i32) = i32::MAX -> Vec::with_capacity(num_parts + 1) huge reservation.
+    let mut b = shp_main_header(500);
+    b.extend_from_slice(&1i32.to_be_bytes()); // record_number
+    b.extend_from_slice(&i32::MAX.to_be_bytes()); // record_size (untrusted, large)
+    b.extend_from_slice(&3i32.to_le_bytes()); // shape_type = Polyline
+    b.extend_from_slice(&[0u8; 32]); // bbox (4x f64)
+    b.extend_from_slice(&i32::MAX.to_le_bytes()); // num_parts = i32::MAX (untrusted)
+    b.extend_from_slice(&0i32.to_le_bytes()); // num_points = 0
+    assert_record_errors("polyline num_parts=MAX", b);
+}
+
+#[test]
+fn shx_negative_file_length_is_rejected_not_panicked() {
+    // A .shx whose file_length (BE i32) is negative sign-extends under `as usize`
+    // to ~1.8e19 and the ShapeIndex Vec reservation overflows capacity / OOMs.
+    let mut reader = ShpReader::new(Cursor::new(shp_main_header(500))).expect("shp header parse");
+    // Returns Err (not a panic / OOM) after the fix.
+    let res = reader.add_index_source(Cursor::new(shp_main_header(-1)));
+    assert!(
+        res.is_err(),
+        "add_index_source accepted negative file_length"
+    );
+}
+
+#[test]
+fn shx_huge_file_length_is_rejected_not_oom() {
+    // file_length = i32::MAX -> after *2 and /INDEX_RECORD_SIZE a huge reservation.
+    let mut reader = ShpReader::new(Cursor::new(shp_main_header(500))).expect("shp header parse");
+    let res = reader.add_index_source(Cursor::new(shp_main_header(i32::MAX)));
+    assert!(res.is_err(), "add_index_source accepted huge file_length");
+}
+
+#[test]
+fn legit_shapefiles_still_parse() {
+    // Regression guard: legitimate fixtures must keep decoding after the budget.
+    for f in &[
+        "line.shp",
+        "poly.shp",
+        "point.shp",
+        "pointm.shp",
+        "pointz.shp",
+        "multipoint.shp",
+        "multipointz.shp",
+        "polygon.shp",
+    ] {
+        let reader = ShpReader::from_path(format!("./tests/data/shp/{f}")).expect("open fixture");
+        let mut sink = ProcessorSink::new();
+        let mut n = 0;
+        for res in reader.iter_geometries(&mut sink) {
+            assert!(res.is_ok(), "legit fixture {f} record failed: {res:?}");
+            n += 1;
+        }
+        assert!(n > 0, "legit fixture {f} yielded no records");
+    }
+}

--- a/geozero/tests/shp-reader.rs
+++ b/geozero/tests/shp-reader.rs
@@ -414,8 +414,6 @@ fn polygonzm() -> Result<(), geozero::shp::Error> {
 // so a tiny malformed record returns `Err` instead of panicking (`capacity overflow`
 // / debug int-overflow) or requesting a multi-GB allocation.
 
-use std::io::Cursor;
-
 /// Build a valid 100-byte shapefile main header so `ShpReader::new` accepts the
 /// stream; `file_length_words` is the (attacker-controlled) file-length field.
 fn shp_main_header(file_length_words: i32) -> Vec<u8> {

--- a/geozero/tests/shp-reader.rs
+++ b/geozero/tests/shp-reader.rs
@@ -475,6 +475,18 @@ fn multipatch_huge_record_size_is_rejected_not_oom() {
 }
 
 #[test]
+fn record_size_below_shape_type_is_rejected_not_panicked() {
+    // record_size = 0 is non-negative but smaller than the 4-byte shape type it
+    // contains, so `record_size - size_of::<i32>()` underflowed (debug panic /
+    // release wrap to ~1.8e19).
+    let mut b = shp_main_header(500);
+    b.extend_from_slice(&1i32.to_be_bytes()); // record_number
+    b.extend_from_slice(&0i32.to_be_bytes()); // record_size = 0 (untrusted)
+    b.extend_from_slice(&1i32.to_le_bytes()); // shape_type = Point
+    assert_record_errors("record_size=0", b);
+}
+
+#[test]
 fn polygon_negative_num_points_is_rejected_not_panicked() {
     // num_points (LE i32) = -1 -> multipart_record_size(16 * -1) debug-mul-overflow /
     // read_xy Vec::with_capacity(~1.8e19) capacity overflow before the fix.


### PR DESCRIPTION
Extends the untrusted-allocation hardening from #297 (`bounded_vec` /
`MAX_PREALLOC_BYTES`) and #299 to the `with-shp` Shapefile reader — the sibling
reader those passes missed, since the budget helpers were gated behind
`with-geo` and `with-shp` doesn't enable it.

The SHP reader fed `i32` count/size fields decoded from untrusted `.shp`/`.shx`
bytes straight to `Vec::with_capacity` / `vec![0; n]`, unbudgeted and without a
sign check. A ~12-byte record suffices:

- multipatch `record_size = -1` → `-1i32 * 2 as usize` = `0xFFFF_FFFF_FFFF_FFFE`
  → `capacity overflow` panic (debug and release);
- polygon/multipoint `num_points = -1` → `attempt to multiply with overflow`
  panic in debug, multi-GB allocation in release;
- `.shx` `file_length` drives `Vec::<ShapeIndex>::with_capacity` the same way.

A second commit covers the same class one step further in: `record_size = 0` is
non-negative but smaller than the 4-byte shape type it contains, so
`record_size - size_of::<i32>()` underflowed.

Fix reuses the existing budget rather than duplicating it: `geometry_processor.rs`
un-gates `MAX_PREALLOC_BYTES` / `bounded_vec` / `validate_capacity` (they have no
`with-geo` deps); `shp_reader.rs` adds `validate_count` to reject negative counts,
uses checked arithmetic for the `* 2` doublings and the multipart size helpers,
and routes every reservation through `bounded_vec`; `shx_reader.rs` validates
`file_length` and bounds the index reservation.

Tests cover each case returning `Err` instead of panicking, plus a guard that the
existing fixtures still parse. `cargo test -p geozero`, `--no-default-features`,
and `--workspace --features with-shp` pass; fmt and clippy clean.
