### PR TITLE
Stop the shp reader iterators on the first error

### DIFF
--- a/geozero/CHANGELOG.md
+++ b/geozero/CHANGELOG.md
@@ -31,6 +31,9 @@
 * Updated to 2024 edition
 * Cleanup justfile, editor config, other minor non-coding aspects
 * Use `fast-mvt` for all MVT handling
+* Fix the `shp` reader iterators never terminating on a malformed or truncated file: an
+  error is now terminal instead of being yielded again forever, and the main header's
+  `file_length` is validated
 
 ## 0.14.0 - (2024-09-26)
 

--- a/geozero/src/shp/header.rs
+++ b/geozero/src/shp/header.rs
@@ -7,9 +7,9 @@ use crate::shp::Error;
 use crate::shp::point_z::BBoxZ;
 
 pub(crate) const HEADER_SIZE: i32 = 100;
-const FILE_CODE: i32 = 9994;
+pub(crate) const FILE_CODE: i32 = 9994;
 /// Size of reserved bytes in the header, that have do defined use
-const SIZE_OF_SKIP: usize = size_of::<i32>() * 5;
+pub(crate) const SIZE_OF_SKIP: usize = size_of::<i32>() * 5;
 
 /// struct representing the Header of a shapefile
 /// can be retrieved via the reader used to read
@@ -220,9 +220,9 @@ mod tests {
         let mut h = Vec::with_capacity(HEADER_SIZE as usize);
         h.extend_from_slice(&FILE_CODE.to_be_bytes());
         h.extend_from_slice(&[0u8; SIZE_OF_SKIP]);
-        h.extend_from_slice(&(ShapeType::Polygon as i32).to_be_bytes());
+        h.extend_from_slice(&file_length_16_bit.to_be_bytes());
         h.extend_from_slice(&1000i32.to_le_bytes()); // version
-        h.extend_from_slice(&shape_type.to_le_bytes());
+        h.extend_from_slice(&(ShapeType::Polygon as i32).to_le_bytes());
         h.extend_from_slice(&[0u8; 64]); // 8 x f64 bbox
         assert_eq!(h.len(), HEADER_SIZE as usize);
         h

--- a/geozero/src/shp/header.rs
+++ b/geozero/src/shp/header.rs
@@ -81,21 +81,6 @@ impl Header {
     }
 }
 
-/// A well-formed 100-byte main header with a caller-chosen `file_length`, for
-/// tests that need the readers to accept the header and then hit the record loop.
-#[cfg(test)]
-pub(crate) fn raw_header(file_length_16_bit: i32, shape_type: i32) -> Vec<u8> {
-    let mut h = Vec::with_capacity(HEADER_SIZE as usize);
-    h.extend_from_slice(&FILE_CODE.to_be_bytes());
-    h.extend_from_slice(&[0u8; SIZE_OF_SKIP]);
-    h.extend_from_slice(&file_length_16_bit.to_be_bytes());
-    h.extend_from_slice(&1000i32.to_le_bytes()); // version
-    h.extend_from_slice(&shape_type.to_le_bytes());
-    h.extend_from_slice(&[0u8; 64]); // 8 x f64 bbox
-    assert_eq!(h.len(), HEADER_SIZE as usize);
-    h
-}
-
 /// The enum for the ShapeType as defined in the
 /// specification
 #[derive(Debug, PartialEq, Copy, Clone)]
@@ -230,13 +215,27 @@ mod tests {
         assert!(Header::read_from(&mut src).is_err());
     }
 
+    /// A well-formed 100-byte main header with a caller-chosen `file_length`
+    fn raw_header(file_length_16_bit: i32) -> Vec<u8> {
+        let mut h = Vec::with_capacity(HEADER_SIZE as usize);
+        h.extend_from_slice(&FILE_CODE.to_be_bytes());
+        h.extend_from_slice(&[0u8; SIZE_OF_SKIP]);
+        h.extend_from_slice(&(ShapeType::Polygon as i32).to_be_bytes());
+        h.extend_from_slice(&1000i32.to_le_bytes()); // version
+        h.extend_from_slice(&shape_type.to_le_bytes());
+        h.extend_from_slice(&[0u8; 64]); // 8 x f64 bbox
+        assert_eq!(h.len(), HEADER_SIZE as usize);
+        h
+    }
+
+    
     #[test]
     fn file_length_shorter_than_the_header_is_rejected() {
         // Left unchecked these sign-extend to ~1.8e19 (negative) or claim a file
         // that ends inside its own header, both of which the readers turn into a
         // bogus iteration extent / record count.
         for file_length in [i32::MIN, -1, 0, 1, HEADER_SIZE / 2 - 1] {
-            let bytes = raw_header(file_length, ShapeType::Polygon as i32);
+            let bytes = raw_header(file_length);
             assert!(
                 Header::read_from(&mut bytes.as_slice()).is_err(),
                 "file_length {file_length} should be rejected"
@@ -247,7 +246,7 @@ mod tests {
     #[test]
     fn header_only_file_length_is_accepted() {
         // 50 words = the 100-byte header exactly: a valid, empty shapefile.
-        let bytes = raw_header(HEADER_SIZE / 2, ShapeType::Polygon as i32);
+        let bytes = raw_header(HEADER_SIZE / 2);
         let hdr = Header::read_from(&mut bytes.as_slice()).unwrap();
         assert_eq!(hdr.file_length, HEADER_SIZE / 2);
         assert_eq!(hdr.shape_type, ShapeType::Polygon);

--- a/geozero/src/shp/header.rs
+++ b/geozero/src/shp/header.rs
@@ -52,6 +52,12 @@ impl Header {
         source.read_exact(&mut skip)?;
 
         let file_length_16_bit = source.read_i32::<BigEndian>()?;
+        // A shapefile cannot be shorter than its own header, so anything below
+        // that is either negative (sign-extends to ~1.8e19 when the readers cast
+        // it `as usize`) or claims a file that stops inside the header.
+        if file_length_16_bit < HEADER_SIZE / 2 {
+            return Err(Error::InvalidShapeRecordSize);
+        }
         let version = source.read_i32::<LittleEndian>()?;
         let shape_type = ShapeType::read_from(&mut source)?;
 
@@ -73,6 +79,21 @@ impl Header {
 
         Ok(hdr)
     }
+}
+
+/// A well-formed 100-byte main header with a caller-chosen `file_length`, for
+/// tests that need the readers to accept the header and then hit the record loop.
+#[cfg(test)]
+pub(crate) fn raw_header(file_length_16_bit: i32, shape_type: i32) -> Vec<u8> {
+    let mut h = Vec::with_capacity(HEADER_SIZE as usize);
+    h.extend_from_slice(&FILE_CODE.to_be_bytes());
+    h.extend_from_slice(&[0u8; SIZE_OF_SKIP]);
+    h.extend_from_slice(&file_length_16_bit.to_be_bytes());
+    h.extend_from_slice(&1000i32.to_le_bytes()); // version
+    h.extend_from_slice(&shape_type.to_le_bytes());
+    h.extend_from_slice(&[0u8; 64]); // 8 x f64 bbox
+    assert_eq!(h.len(), HEADER_SIZE as usize);
+    h
 }
 
 /// The enum for the ShapeType as defined in the
@@ -207,5 +228,28 @@ mod tests {
 
         src.seek(SeekFrom::Start(0)).unwrap();
         assert!(Header::read_from(&mut src).is_err());
+    }
+
+    #[test]
+    fn file_length_shorter_than_the_header_is_rejected() {
+        // Left unchecked these sign-extend to ~1.8e19 (negative) or claim a file
+        // that ends inside its own header, both of which the readers turn into a
+        // bogus iteration extent / record count.
+        for file_length in [i32::MIN, -1, 0, 1, HEADER_SIZE / 2 - 1] {
+            let bytes = raw_header(file_length, ShapeType::Polygon as i32);
+            assert!(
+                Header::read_from(&mut bytes.as_slice()).is_err(),
+                "file_length {file_length} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn header_only_file_length_is_accepted() {
+        // 50 words = the 100-byte header exactly: a valid, empty shapefile.
+        let bytes = raw_header(HEADER_SIZE / 2, ShapeType::Polygon as i32);
+        let hdr = Header::read_from(&mut bytes.as_slice()).unwrap();
+        assert_eq!(hdr.file_length, HEADER_SIZE / 2);
+        assert_eq!(hdr.shape_type, ShapeType::Polygon);
     }
 }

--- a/geozero/src/shp/header.rs
+++ b/geozero/src/shp/header.rs
@@ -228,7 +228,6 @@ mod tests {
         h
     }
 
-    
     #[test]
     fn file_length_shorter_than_the_header_is_rejected() {
         // Left unchecked these sign-extend to ~1.8e19 (negative) or claim a file

--- a/geozero/src/shp/reader.rs
+++ b/geozero/src/shp/reader.rs
@@ -16,10 +16,7 @@ pub struct ShapeIterator<'a, P: GeomProcessor, T: Read> {
     source: T,
     current_pos: usize,
     file_length: usize,
-    /// Set once an error has been yielded. `current_pos` only advances over a
-    /// record that was read in full, so after a failure the byte stream is
-    /// desynchronised and there is nothing left to resume from.
-    done: bool,
+    encountered_error: bool,
 }
 
 impl<P: GeomProcessor, T: Read> ShapeIterator<'_, P, T> {
@@ -44,11 +41,11 @@ impl<'a, P: GeomProcessor, T: Read + 'a> Iterator for ShapeIterator<'a, P, T> {
     type Item = Result<(), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.done || self.current_pos >= self.file_length {
+        if self.encountered_error || self.current_pos >= self.file_length {
             return None;
         }
         let result = self.read_record();
-        self.done = result.is_err();
+        self.encountered_error = result.is_err();
         Some(result)
     }
 }
@@ -59,10 +56,7 @@ pub struct ShapeRecordIterator<'a, P: FeatureProcessor, T: Read + Seek> {
     shape_iter: ShapeIterator<'a, P, T>,
     dbf_reader: dbase::Reader<T>,
     featno: u64,
-    /// Set once the iterator is finished, so `dataset_end` is emitted exactly
-    /// once and a failed feature is not retried against a stream that has
-    /// already moved on. See [`ShapeIterator::done`].
-    done: bool,
+    encountered_error: bool,
 }
 
 pub struct ShapeRecord {
@@ -73,23 +67,20 @@ impl<'a, P: FeatureProcessor, T: Read + Seek + 'a> Iterator for ShapeRecordItera
     type Item = Result<ShapeRecord, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.done {
+        if self.encountered_error {
             return None;
         }
         if self.featno == 0 {
             self.shape_iter.processor.dataset_begin(None).ok();
         }
-        // Stop on shape-file EOF: since dbase 0.8 the dbf record iterator no
-        // longer returns None at EOF, so it can't drive termination here.
+        // dbf record iterator does not return None at EOF, so can't drive termination
         if self.shape_iter.current_pos >= self.shape_iter.file_length {
-            self.done = true;
             self.shape_iter.processor.dataset_end().ok();
             return None;
         }
         let result = self.read_feature();
-        // Any error is terminal: the shape stream, the dbf stream and the
-        // processor's event stream are all left mid-feature.
-        self.done = !matches!(result, Some(Ok(_)));
+        // shape stream, dbf stream and the processor's event stream are all left mid-feature.
+        self.encountered_error = !matches!(result, Some(Ok(_)));
         result
     }
 }
@@ -195,12 +186,8 @@ impl<T: Read + Seek> ShpReader<T> {
             processor,
             source: self.source,
             current_pos: header::HEADER_SIZE as usize,
-            // `file_length` is in 16-bit words. Double it in `usize`: doing it in
-            // `i32` overflows for a header claiming close to `i32::MAX` words, and
-            // this method has no way to report that. `Header::read_from` has
-            // already rejected values below the header size, so the cast is sound.
             file_length: (self.header.file_length as usize).saturating_mul(2),
-            done: false,
+            encountered_error: false,
         }
     }
 
@@ -220,7 +207,7 @@ impl<T: Read + Seek> ShpReader<T> {
                 shape_iter,
                 dbf_reader,
                 featno: 0,
-                done: false,
+                encountered_error: false,
             })
         } else {
             Err(Error::MissingDbf)
@@ -406,7 +393,6 @@ mod tests {
 
     #[test]
     fn negative_record_size_is_rejected_not_panicked() {
-        // `record_size as usize * 2` overflows on a negative size.
         let mut bytes = raw_header(5000, ShapeType::Polygon as i32);
         bytes.extend(shape_record(1, -1, &[0u8; 32]));
         assert_eq!(geometries(bytes), (0, 1));
@@ -414,8 +400,6 @@ mod tests {
 
     #[test]
     fn huge_file_length_does_not_overflow_the_iteration_extent() {
-        // `file_length * 2` overflows if it is done in i32, and `iter_geometries`
-        // has no way to report that.
         assert_eq!(
             geometries(raw_header(i32::MAX, ShapeType::Polygon as i32)),
             (0, 1)
@@ -445,8 +429,6 @@ mod tests {
 
     #[test]
     fn truncated_shp_stops_the_feature_iterator() {
-        // The crate's own documented entry point (`iter_features(..)?.count()`)
-        // against a truncated copy of the poly fixture.
         let shp = std::fs::read(POLY_SHP).unwrap();
         let dbf = std::fs::read(POLY_DBF).unwrap();
         assert_eq!(features(shp[..600].to_vec(), dbf), (1, 1));

--- a/geozero/src/shp/reader.rs
+++ b/geozero/src/shp/reader.rs
@@ -16,23 +16,40 @@ pub struct ShapeIterator<'a, P: GeomProcessor, T: Read> {
     source: T,
     current_pos: usize,
     file_length: usize,
+    /// Set once an error has been yielded. `current_pos` only advances over a
+    /// record that was read in full, so after a failure the byte stream is
+    /// desynchronised and there is nothing left to resume from.
+    done: bool,
+}
+
+impl<P: GeomProcessor, T: Read> ShapeIterator<'_, P, T> {
+    /// Read one record and advance `current_pos` past it.
+    fn read_record(&mut self) -> Result<(), Error> {
+        let hdr = read_shape(self.processor, &mut self.source)?;
+        // `record_size` is in 16-bit words and comes straight off the record
+        // header, so it can be negative or large enough to overflow the doubling.
+        let record_size = usize::try_from(hdr.record_size)
+            .ok()
+            .and_then(|size| size.checked_mul(2))
+            .ok_or(Error::InvalidShapeRecordSize)?;
+        self.current_pos = self
+            .current_pos
+            .saturating_add(RecordHeader::SIZE)
+            .saturating_add(record_size);
+        Ok(())
+    }
 }
 
 impl<'a, P: GeomProcessor, T: Read + 'a> Iterator for ShapeIterator<'a, P, T> {
     type Item = Result<(), Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.current_pos >= self.file_length {
-            None
-        } else {
-            let hdr = match read_shape(self.processor, &mut self.source) {
-                Err(e) => return Some(Err(e)),
-                Ok(hdr_and_shape) => hdr_and_shape,
-            };
-            self.current_pos += RecordHeader::SIZE;
-            self.current_pos += hdr.record_size as usize * 2;
-            Some(Ok(()))
+        if self.done || self.current_pos >= self.file_length {
+            return None;
         }
+        let result = self.read_record();
+        self.done = result.is_err();
+        Some(result)
     }
 }
 
@@ -42,6 +59,10 @@ pub struct ShapeRecordIterator<'a, P: FeatureProcessor, T: Read + Seek> {
     shape_iter: ShapeIterator<'a, P, T>,
     dbf_reader: dbase::Reader<T>,
     featno: u64,
+    /// Set once the iterator is finished, so `dataset_end` is emitted exactly
+    /// once and a failed feature is not retried against a stream that has
+    /// already moved on. See [`ShapeIterator::done`].
+    done: bool,
 }
 
 pub struct ShapeRecord {
@@ -52,15 +73,29 @@ impl<'a, P: FeatureProcessor, T: Read + Seek + 'a> Iterator for ShapeRecordItera
     type Item = Result<ShapeRecord, Error>;
 
     fn next(&mut self) -> Option<Self::Item> {
+        if self.done {
+            return None;
+        }
         if self.featno == 0 {
             self.shape_iter.processor.dataset_begin(None).ok();
         }
         // Stop on shape-file EOF: since dbase 0.8 the dbf record iterator no
         // longer returns None at EOF, so it can't drive termination here.
         if self.shape_iter.current_pos >= self.shape_iter.file_length {
+            self.done = true;
             self.shape_iter.processor.dataset_end().ok();
             return None;
         }
+        let result = self.read_feature();
+        // Any error is terminal: the shape stream, the dbf stream and the
+        // processor's event stream are all left mid-feature.
+        self.done = !matches!(result, Some(Ok(_)));
+        result
+    }
+}
+
+impl<'a, P: FeatureProcessor, T: Read + Seek + 'a> ShapeRecordIterator<'a, P, T> {
+    fn read_feature(&mut self) -> Option<Result<ShapeRecord, Error>> {
         let record = match self.dbf_reader.iter_records().next() {
             None => {
                 self.shape_iter.processor.dataset_end().ok();
@@ -160,7 +195,12 @@ impl<T: Read + Seek> ShpReader<T> {
             processor,
             source: self.source,
             current_pos: header::HEADER_SIZE as usize,
-            file_length: (self.header.file_length * 2) as usize,
+            // `file_length` is in 16-bit words. Double it in `usize`: doing it in
+            // `i32` overflows for a header claiming close to `i32::MAX` words, and
+            // this method has no way to report that. `Header::read_from` has
+            // already rejected values below the header size, so the cast is sound.
+            file_length: (self.header.file_length as usize).saturating_mul(2),
+            done: false,
         }
     }
 
@@ -180,6 +220,7 @@ impl<T: Read + Seek> ShpReader<T> {
                 shape_iter,
                 dbf_reader,
                 featno: 0,
+                done: false,
             })
         } else {
             Err(Error::MissingDbf)
@@ -254,3 +295,186 @@ impl ShpReader<BufReader<File>> {
 //         }
 //     }
 // }
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::shp::header::{HEADER_SIZE, ShapeType, raw_header};
+    use crate::{ColumnValue, ProcessorSink, PropertyProcessor, error::GeozeroError};
+
+    const POLY_SHP: &str = "./tests/data/shp/poly.shp";
+    const POLY_DBF: &str = "./tests/data/shp/poly.dbf";
+
+    /// One shape record: 8-byte header (number, size in 16-bit words, both
+    /// big-endian) followed by the shape body.
+    fn shape_record(number: i32, size_16_bit: i32, body: &[u8]) -> Vec<u8> {
+        let mut r = number.to_be_bytes().to_vec();
+        r.extend_from_slice(&size_16_bit.to_be_bytes());
+        r.extend_from_slice(body);
+        r
+    }
+
+    fn point_body(x: f64, y: f64) -> Vec<u8> {
+        let mut b = (ShapeType::Point as i32).to_le_bytes().to_vec();
+        b.extend_from_slice(&x.to_le_bytes());
+        b.extend_from_slice(&y.to_le_bytes());
+        b
+    }
+
+    /// `file_length` (in 16-bit words) for a shapefile of exactly `bytes` bytes.
+    fn words(bytes: usize) -> i32 {
+        i32::try_from(bytes / 2).unwrap()
+    }
+
+    /// Pull at most `LIMIT` items and return `(ok_count, err_count)`.
+    ///
+    /// Panics if the iterator has not finished by then, so a non-terminating
+    /// iterator fails the test instead of hanging it. Also asserts the iterator
+    /// stays exhausted, as its `FusedIterator` impl promises.
+    fn drain<I, T, E>(mut it: I) -> (usize, usize)
+    where
+        I: Iterator<Item = Result<T, E>>,
+    {
+        const LIMIT: usize = 64;
+        let (mut oks, mut errs) = (0, 0);
+        for _ in 0..LIMIT {
+            match it.next() {
+                None => {
+                    assert!(it.next().is_none(), "iterator resumed after None");
+                    return (oks, errs);
+                }
+                Some(Ok(_)) => oks += 1,
+                Some(Err(_)) => errs += 1,
+            }
+        }
+        panic!("iterator still going after {LIMIT} items ({oks} Ok, {errs} Err)");
+    }
+
+    fn geometries(bytes: Vec<u8>) -> (usize, usize) {
+        let reader = ShpReader::new(Cursor::new(bytes)).expect("header should parse");
+        let mut sink = ProcessorSink::new();
+        drain(reader.iter_geometries(&mut sink))
+    }
+
+    fn features(shp: Vec<u8>, dbf: Vec<u8>) -> (usize, usize) {
+        let mut reader = ShpReader::new(Cursor::new(shp)).expect("header should parse");
+        reader.add_dbf_source(Cursor::new(dbf)).unwrap();
+        let mut sink = ProcessorSink::new();
+        drain(reader.iter_features(&mut sink).unwrap())
+    }
+
+    #[test]
+    fn truncated_file_reports_one_error_and_stops() {
+        // The header is entirely well formed and claims 1000 bytes; the file is
+        // the 100-byte header alone. Every truncated download looks like this.
+        assert_eq!(
+            geometries(raw_header(500, ShapeType::Polygon as i32)),
+            (0, 1)
+        );
+    }
+
+    #[test]
+    fn truncation_after_a_valid_record_reports_one_error_and_stops() {
+        let mut bytes = raw_header(5000, ShapeType::Point as i32);
+        bytes.extend(shape_record(1, 10, &point_body(1.0, 2.0)));
+        assert_eq!(geometries(bytes), (1, 1));
+    }
+
+    #[test]
+    fn invalid_shape_type_reports_one_error_and_stops() {
+        let mut body = 60i32.to_le_bytes().to_vec(); // not a ShapeType
+        body.extend_from_slice(&[0u8; 16]);
+        let mut bytes = raw_header(5000, ShapeType::Polygon as i32);
+        bytes.extend(shape_record(1, 10, &body));
+        assert_eq!(geometries(bytes), (0, 1));
+    }
+
+    #[test]
+    fn negative_record_size_is_rejected_not_panicked() {
+        // `record_size as usize * 2` overflows on a negative size.
+        let mut bytes = raw_header(5000, ShapeType::Polygon as i32);
+        bytes.extend(shape_record(1, -1, &[0u8; 32]));
+        assert_eq!(geometries(bytes), (0, 1));
+    }
+
+    #[test]
+    fn huge_file_length_does_not_overflow_the_iteration_extent() {
+        // `file_length * 2` overflows if it is done in i32, and `iter_geometries`
+        // has no way to report that.
+        assert_eq!(
+            geometries(raw_header(i32::MAX, ShapeType::Polygon as i32)),
+            (0, 1)
+        );
+    }
+
+    #[test]
+    fn header_only_file_yields_no_geometries() {
+        assert_eq!(
+            geometries(raw_header(HEADER_SIZE / 2, ShapeType::Polygon as i32)),
+            (0, 0)
+        );
+    }
+
+    #[test]
+    fn well_formed_file_yields_every_record() {
+        let records: Vec<u8> = (1..=3)
+            .flat_map(|n| shape_record(n, 10, &point_body(f64::from(n), 2.0)))
+            .collect();
+        let mut bytes = raw_header(
+            words(HEADER_SIZE as usize + records.len()),
+            ShapeType::Point as i32,
+        );
+        bytes.extend(records);
+        assert_eq!(geometries(bytes), (3, 0));
+    }
+
+    #[test]
+    fn truncated_shp_stops_the_feature_iterator() {
+        // The crate's own documented entry point (`iter_features(..)?.count()`)
+        // against a truncated copy of the poly fixture.
+        let shp = std::fs::read(POLY_SHP).unwrap();
+        let dbf = std::fs::read(POLY_DBF).unwrap();
+        assert_eq!(features(shp[..600].to_vec(), dbf), (1, 1));
+    }
+
+    #[test]
+    fn truncated_dbf_stops_the_feature_iterator() {
+        let shp = std::fs::read(POLY_SHP).unwrap();
+        let dbf = std::fs::read(POLY_DBF).unwrap();
+        let (_, errs) = features(shp, dbf[..dbf.len() / 2].to_vec());
+        assert_eq!(errs, 1);
+    }
+
+    #[test]
+    fn processor_error_stops_the_feature_iterator() {
+        struct FailingProperties;
+        impl GeomProcessor for FailingProperties {}
+        impl FeatureProcessor for FailingProperties {}
+        impl PropertyProcessor for FailingProperties {
+            fn property(
+                &mut self,
+                _idx: usize,
+                _name: &str,
+                _value: &ColumnValue,
+            ) -> crate::error::Result<bool> {
+                Err(GeozeroError::Property("rejected".to_string()))
+            }
+        }
+
+        let shp = std::fs::read(POLY_SHP).unwrap();
+        let dbf = std::fs::read(POLY_DBF).unwrap();
+        let mut reader = ShpReader::new(Cursor::new(shp)).unwrap();
+        reader.add_dbf_source(Cursor::new(dbf)).unwrap();
+        let mut processor = FailingProperties;
+        assert_eq!(drain(reader.iter_features(&mut processor).unwrap()), (0, 1));
+    }
+
+    #[test]
+    fn well_formed_shapefile_yields_every_feature() {
+        let shp = std::fs::read(POLY_SHP).unwrap();
+        let dbf = std::fs::read(POLY_DBF).unwrap();
+        assert_eq!(features(shp, dbf), (10, 0));
+    }
+}

--- a/geozero/src/shp/reader.rs
+++ b/geozero/src/shp/reader.rs
@@ -288,7 +288,7 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
-    use crate::shp::header::{HEADER_SIZE, SIZE_OF_SKIP, FILE_CODE, ShapeType};
+    use crate::shp::header::{FILE_CODE, HEADER_SIZE, SIZE_OF_SKIP, ShapeType};
     use crate::{ColumnValue, ProcessorSink, PropertyProcessor, error::GeozeroError};
 
     const POLY_SHP: &str = "./tests/data/shp/poly.shp";

--- a/geozero/src/shp/reader.rs
+++ b/geozero/src/shp/reader.rs
@@ -288,7 +288,7 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
-    use crate::shp::header::{HEADER_SIZE, ShapeType, raw_header};
+    use crate::shp::header::{HEADER_SIZE, ShapeType};
     use crate::{ColumnValue, ProcessorSink, PropertyProcessor, error::GeozeroError};
 
     const POLY_SHP: &str = "./tests/data/shp/poly.shp";
@@ -357,9 +357,9 @@ mod tests {
         let mut h = Vec::with_capacity(HEADER_SIZE as usize);
         h.extend_from_slice(&FILE_CODE.to_be_bytes());
         h.extend_from_slice(&[0u8; SIZE_OF_SKIP]);
-        h.extend_from_slice(&(ShapeType::Polygon as i32).to_be_bytes());
+        h.extend_from_slice(&file_length_16_bit.to_be_bytes());
         h.extend_from_slice(&1000i32.to_le_bytes()); // version
-        h.extend_from_slice(&shape_type.to_le_bytes());
+        h.extend_from_slice(&(ShapeType::Polygon as i32).to_le_bytes());
         h.extend_from_slice(&[0u8; 64]); // 8 x f64 bbox
         assert_eq!(h.len(), HEADER_SIZE as usize);
         h
@@ -369,15 +369,12 @@ mod tests {
     fn truncated_file_reports_one_error_and_stops() {
         // The header is entirely well formed and claims 1000 bytes; the file is
         // the 100-byte header alone. Every truncated download looks like this.
-        assert_eq!(
-            geometries(raw_header(500, ShapeType::Polygon as i32)),
-            (0, 1)
-        );
+        assert_eq!(geometries(raw_header(500)), (0, 1));
     }
 
     #[test]
     fn truncation_after_a_valid_record_reports_one_error_and_stops() {
-        let mut bytes = raw_header(5000, ShapeType::Point as i32);
+        let mut bytes = raw_header(5000);
         bytes.extend(shape_record(1, 10, &point_body(1.0, 2.0)));
         assert_eq!(geometries(bytes), (1, 1));
     }
@@ -386,32 +383,26 @@ mod tests {
     fn invalid_shape_type_reports_one_error_and_stops() {
         let mut body = 60i32.to_le_bytes().to_vec(); // not a ShapeType
         body.extend_from_slice(&[0u8; 16]);
-        let mut bytes = raw_header(5000, ShapeType::Polygon as i32);
+        let mut bytes = raw_header(5000);
         bytes.extend(shape_record(1, 10, &body));
         assert_eq!(geometries(bytes), (0, 1));
     }
 
     #[test]
     fn negative_record_size_is_rejected_not_panicked() {
-        let mut bytes = raw_header(5000, ShapeType::Polygon as i32);
+        let mut bytes = raw_header(5000);
         bytes.extend(shape_record(1, -1, &[0u8; 32]));
         assert_eq!(geometries(bytes), (0, 1));
     }
 
     #[test]
     fn huge_file_length_does_not_overflow_the_iteration_extent() {
-        assert_eq!(
-            geometries(raw_header(i32::MAX, ShapeType::Polygon as i32)),
-            (0, 1)
-        );
+        assert_eq!(geometries(raw_header(i32::MAX)), (0, 1));
     }
 
     #[test]
     fn header_only_file_yields_no_geometries() {
-        assert_eq!(
-            geometries(raw_header(HEADER_SIZE / 2, ShapeType::Polygon as i32)),
-            (0, 0)
-        );
+        assert_eq!(geometries(raw_header(HEADER_SIZE / 2)), (0, 0));
     }
 
     #[test]
@@ -419,10 +410,7 @@ mod tests {
         let records: Vec<u8> = (1..=3)
             .flat_map(|n| shape_record(n, 10, &point_body(f64::from(n), 2.0)))
             .collect();
-        let mut bytes = raw_header(
-            words(HEADER_SIZE as usize + records.len()),
-            ShapeType::Point as i32,
-        );
+        let mut bytes = raw_header(words(HEADER_SIZE as usize + records.len()));
         bytes.extend(records);
         assert_eq!(geometries(bytes), (3, 0));
     }

--- a/geozero/src/shp/reader.rs
+++ b/geozero/src/shp/reader.rs
@@ -288,7 +288,7 @@ mod tests {
     use std::io::Cursor;
 
     use super::*;
-    use crate::shp::header::{HEADER_SIZE, ShapeType};
+    use crate::shp::header::{HEADER_SIZE, SIZE_OF_SKIP, FILE_CODE, ShapeType};
     use crate::{ColumnValue, ProcessorSink, PropertyProcessor, error::GeozeroError};
 
     const POLY_SHP: &str = "./tests/data/shp/poly.shp";

--- a/geozero/src/shp/reader.rs
+++ b/geozero/src/shp/reader.rs
@@ -365,6 +365,19 @@ mod tests {
         drain(reader.iter_features(&mut sink).unwrap())
     }
 
+    /// A well-formed 100-byte main header with a caller-chosen `file_length`
+    fn raw_header(file_length_16_bit: i32) -> Vec<u8> {
+        let mut h = Vec::with_capacity(HEADER_SIZE as usize);
+        h.extend_from_slice(&FILE_CODE.to_be_bytes());
+        h.extend_from_slice(&[0u8; SIZE_OF_SKIP]);
+        h.extend_from_slice(&(ShapeType::Polygon as i32).to_be_bytes());
+        h.extend_from_slice(&1000i32.to_le_bytes()); // version
+        h.extend_from_slice(&shape_type.to_le_bytes());
+        h.extend_from_slice(&[0u8; 64]); // 8 x f64 bbox
+        assert_eq!(h.len(), HEADER_SIZE as usize);
+        h
+    }
+
     #[test]
     fn truncated_file_reports_one_error_and_stops() {
         // The header is entirely well formed and claims 1000 bytes; the file is


### PR DESCRIPTION
Both `Iterator` impls in `shp/reader.rs` decide `None` from state that no error path updates: `current_pos` only advances over a record that was read in full, and it is compared against a `file_length` taken straight from the untrusted header. So every error arm returns `Some(Err(..))` without advancing or finishing, and a malformed or truncated `.shp` yields the same error forever — no panic, no diagnostic, just 100% CPU. Repro against the fixture in this repo:

```rust
let shp = &std::fs::read("geozero/tests/data/shp/poly.shp")?[..600]; // truncate
let reader = ShpReader::new(Cursor::new(shp))?;                      // header parses fine
reader.iter_geometries(&mut ProcessorSink::new()).count();           // never returns
```

That also hangs `iter_features(..)?.count()`, the one-liner in the `shp` module docs. The CHANGELOG already describes this bug for `iter_features` ("looping forever / erroring at end-of-file"); the guard added then only fires when the header's `file_length` is honest, and `ShapeIterator` never got it.

Fix: make an error terminal in both iterators. For a sequential byte-stream reader whose source has desynchronised there is nothing to resume from, and it makes the `FusedIterator` impls the file already declares mean something. This covers all three error arms of `ShapeRecordIterator::next`, not just the shape one — I measured the dbase arm and the property-processing arm separately (truncated `.dbf`, and a processor that returns `Err` from `property()`) and both flood identically; fixing `ShapeIterator` alone does not stop them.

Plus the untrusted header arithmetic those extents are built from:

- `Header::read_from` rejects a `file_length` below the 100-byte header every shapefile has. A negative value sign-extended to a ~1.8e19 extent; a value below the header size decoded as an empty dataset with no error at all.
- `iter_geometries` doubles `file_length` in `usize` — in `i32` it overflows for a header near `i32::MAX` words, and that method can't report an error.
- the iterator's `record_size` doubling is checked instead of `as usize * 2`, which overflowed on a negative size.

I reused `InvalidShapeRecordSize` rather than growing the public error enum; happy to add a dedicated variant if you'd prefer.

11 tests, in `#[cfg(test)] mod tests` next to the code (`tests/shp-reader.rs` untouched). 9 of them fail on `main`; they use a bounded pull so a regression fails fast instead of hanging CI. Positive controls cover a well-formed file for both iterators. Independent of #320 — disjoint files, merges either order.
